### PR TITLE
fix(ci): use Node 24 and stabilize upstream sync push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: '24.x'
 
       - name: Install corepack
         run: corepack enable

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Generate metadata
         run: |

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -53,6 +53,7 @@ jobs:
         run: |
           git remote remove origin
           git remote add origin https://x-access-token:${PAT}@github.com/${{ github.repository }}.git
+          git fetch origin main
           git checkout main
           if git merge-base --is-ancestor upstream/${UPSTREAM_BRANCH} main; then
             echo "Main already contains upstream."
@@ -63,7 +64,7 @@ jobs:
             echo "Rebase failed. Resolve conflicts manually."
             exit 1
           fi
-          git push origin main --force-with-lease
+          git push origin main --force-with-lease=main
 
       - name: Open issue on failure
         if: failure()


### PR DESCRIPTION
### Motivation
- Align GitHub Actions Node versions with the project engine (`node >=24.0.0`) to avoid runtime/version mismatches during build and metadata steps.
- Stabilize the upstream sync job which was failing when `--force-with-lease` had no up-to-date remote reference and to make the push target explicit.

### Description
- Update `.github/workflows/build.yml` to use `node-version: '24.x'` for the build job.
- Update `.github/workflows/deploy-docker.yml` to use `node-version: 24` for the metadata/docker job.
- Update `.github/workflows/sync-upstream.yml` to run `git fetch origin main` before checking out `main` and change the push to `git push origin main --force-with-lease=main`.

### Testing
- No automated tests were run because these are CI workflow changes; validation will occur when workflows run in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a5482acb08324aa1d39e3ca3f80a5)