### PR TITLE
feat(proxy): proxy subtitle URLs through the built-in proxy

### DIFF
--- a/packages/core/src/config/schema/proxy.ts
+++ b/packages/core/src/config/schema/proxy.ts
@@ -138,6 +138,15 @@ export const proxySchema = {
       requiresRestart: false,
       secret: false,
     },
+    proxySubtitles: {
+      schema: z.union([z.boolean(), z.null()]),
+      default: null,
+      label: 'Default proxy subtitles',
+      description: 'When set, used as the default for proxying subtitle URLs.',
+      env: 'DEFAULT_PROXY_PROXY_SUBTITLES',
+      requiresRestart: false,
+      secret: false,
+    },
   },
   force: {
     enabled: {
@@ -210,6 +219,15 @@ export const proxySchema = {
       label: 'Forced proxied services',
       description: 'List of serviceIds to force-proxy. JSON array of strings.',
       env: 'FORCE_PROXY_PROXIED_SERVICES',
+      requiresRestart: false,
+      secret: false,
+    },
+    proxySubtitles: {
+      schema: z.union([z.boolean(), z.null()]),
+      default: null,
+      label: 'Force proxy subtitles',
+      description: 'Override user choice of whether subtitle URLs are proxied.',
+      env: 'FORCE_PROXY_PROXY_SUBTITLES',
       requiresRestart: false,
       secret: false,
     },

--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -115,6 +115,7 @@ const StreamProxyConfig = z.object({
   publicIp: z.string().optional(),
   proxiedAddons: z.array(z.string().min(1)).optional(),
   proxiedServices: z.array(z.string().min(1)).optional(),
+  proxySubtitles: z.boolean().optional(),
 });
 
 export type StreamProxyConfig = z.infer<typeof StreamProxyConfig>;
@@ -1362,6 +1363,7 @@ const StatusResponseSchema = z.object({
         credentials: z.string().or(z.null()),
         disableProxiedAddons: z.boolean(),
         proxiedServices: z.array(z.string()).or(z.null()),
+        proxySubtitles: z.boolean().or(z.null()),
       }),
     }),
     defaults: z.object({
@@ -1373,6 +1375,7 @@ const StatusResponseSchema = z.object({
         publicIp: z.string().or(z.null()),
         credentials: z.string().or(z.null()),
         proxiedServices: z.array(z.string()).or(z.null()),
+        proxySubtitles: z.boolean().or(z.null()),
       }),
       timeout: z.number().or(z.null()),
     }),

--- a/packages/core/src/main/resources.ts
+++ b/packages/core/src/main/resources.ts
@@ -5,6 +5,7 @@ import {
   Env,
   ExtrasParser,
   makeUrlLogSafe,
+  encryptString,
 } from '../utils/index.js';
 import { config as appConfig } from '../config/index.js';
 import { getAddonName } from '../utils/general.js';
@@ -22,6 +23,7 @@ import type {
   ParsedStream,
   Subtitle,
   AddonCatalog,
+  UserData,
 } from '../db/schemas.js';
 import type { Addon } from '../db/index.js';
 import type { Metadata } from '../metadata/utils.js';
@@ -931,6 +933,75 @@ export async function getMeta(
   return { success: false, data: null, errors };
 }
 
+function proxifySubtitleUrls(
+  subtitles: Subtitle[],
+  userData: UserData
+): Subtitle[] {
+  if (!userData.proxy?.proxySubtitles) return subtitles;
+
+  let credentials: string | undefined;
+  const proxy = userData.proxy;
+  if (proxy.id === 'builtin' && proxy.credentials) {
+    credentials = proxy.credentials;
+  } else {
+    const authEntries = appConfig.bootstrap.auth
+      ? Array.from(appConfig.bootstrap.auth.entries())
+      : [];
+    if (authEntries.length > 0) {
+      credentials = `${authEntries[0][0]}:${authEntries[0][1]}`;
+    }
+  }
+
+  if (!credentials) {
+    logger.warn(
+      'proxySubtitles is enabled but no builtin proxy credentials are available'
+    );
+    return subtitles;
+  }
+
+  const [username, ...rest] = credentials.split(':');
+  const password = rest.join(':');
+  const baseUrl = appConfig.bootstrap.baseUrl;
+
+  const { success: authOk, data: encryptedAuth } = encryptString(
+    JSON.stringify({ username, password })
+  );
+  if (!authOk || !encryptedAuth) {
+    logger.error('failed to encrypt subtitle proxy auth');
+    return subtitles;
+  }
+
+  let baseHost: string;
+  try {
+    baseHost = new URL(baseUrl).host;
+  } catch {
+    logger.error({ baseUrl }, 'invalid baseUrl for subtitle proxification');
+    return subtitles;
+  }
+
+  return subtitles.map((subtitle) => {
+    if (!subtitle.url) return subtitle;
+    try {
+      if (new URL(subtitle.url).host === baseHost) return subtitle;
+    } catch {
+      return subtitle;
+    }
+
+    const { success: dataOk, data: encryptedData } = encryptString(
+      JSON.stringify({ url: subtitle.url })
+    );
+    if (!dataOk || !encryptedData) {
+      logger.error({ url: subtitle.url }, 'failed to encrypt subtitle proxy data');
+      return subtitle;
+    }
+
+    return {
+      ...subtitle,
+      url: `${baseUrl}/api/v1/proxy/e.${encryptedAuth}.${encryptedData}/subtitle`,
+    };
+  });
+}
+
 export async function getSubtitles(
   ctx: AIOStreamsContext,
   type: string,
@@ -967,6 +1038,8 @@ export async function getSubtitles(
       }
     })
   );
+
+  allSubtitles = proxifySubtitleUrls(allSubtitles, ctx.userData);
 
   return { success: true, data: allSubtitles, errors };
 }

--- a/packages/frontend/src/components/menu/proxy.tsx
+++ b/packages/frontend/src/components/menu/proxy.tsx
@@ -25,6 +25,7 @@ type ProxyConfig = {
   publicIp?: string;
   proxiedAddons?: string[];
   proxiedServices?: string[];
+  proxySubtitles?: boolean;
 };
 
 export function ProxyMenu() {
@@ -84,6 +85,7 @@ function Content() {
   const isCredentialsForced = isForced?.credentials !== null;
   const isServicesForced = isForced?.proxiedServices !== null;
   const isProxiedAddonsDisabled = isForced?.disableProxiedAddons;
+  const isSubtitlesForced = isForced?.proxySubtitles !== null;
 
   const selectedProxyDetails = userData.proxy?.id
     ? details[userData.proxy.id]
@@ -292,6 +294,25 @@ function Content() {
               />
               <p className="text-[--muted] text-sm">
                 Only streams from these addons will be proxied
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Switch
+                side="right"
+                label="Proxy Subtitles"
+                value={userData.proxy?.proxySubtitles ?? false}
+                onValueChange={(v) => {
+                  setUserData((prev) => ({
+                    ...prev,
+                    proxy: { ...prev.proxy, proxySubtitles: v },
+                  }));
+                }}
+                disabled={isSubtitlesForced || !userData.proxy?.enabled}
+              />
+              <p className="text-[--muted] text-sm">
+                Rewrite subtitle URLs through the built-in proxy so Stremio can
+                reach internally-hosted subtitle services.
               </p>
             </div>
           </SettingsCard>

--- a/packages/frontend/src/context/userData.tsx
+++ b/packages/frontend/src/context/userData.tsx
@@ -505,6 +505,8 @@ export function UserDataProvider({ children }: { children: React.ReactNode }) {
           forced.proxy.credentials ?? defaults.proxy?.credentials ?? undefined,
         proxiedServices:
           forced.proxy.proxiedServices ?? defaults.proxy?.proxiedServices ?? [],
+        proxySubtitles:
+          forced.proxy.proxySubtitles ?? defaults.proxy?.proxySubtitles ?? undefined,
       };
 
       newData.services = (newData.services ?? []).map((service) => {

--- a/packages/server/src/routes/api/status.ts
+++ b/packages/server/src/routes/api/status.ts
@@ -75,6 +75,7 @@ const statusInfo = async (): Promise<StatusResponse> => {
             : null,
           proxiedServices: appConfig.proxy.force.proxiedServices ?? null,
           disableProxiedAddons: appConfig.proxy.force.disableProxiedAddons,
+          proxySubtitles: appConfig.proxy.force.proxySubtitles ?? null,
         },
       },
       defaults: {
@@ -92,6 +93,7 @@ const statusInfo = async (): Promise<StatusResponse> => {
             ? encryptString(appConfig.proxy.default.credentials).data
             : null,
           proxiedServices: appConfig.proxy.default.proxiedServices ?? null,
+          proxySubtitles: appConfig.proxy.default.proxySubtitles ?? null,
         },
         timeout: appConfig.presets.defaultTimeout ?? null,
       },


### PR DESCRIPTION
## Summary

- Adds a **Proxy Subtitles** toggle that rewrites subtitle URLs returned by `getSubtitles()` through `/api/v1/proxy/e.{auth}.{data}/subtitle` — the same encrypted URL shape used for streams — so Stremio can reach internally-hosted subtitle services (e.g. Submaker running as `http://submaker:7001/...`) via the public AIOStreams URL.
- All configuration surfaces are covered, matching the exact pattern used by `proxiedServices`/`proxiedAddons`.

### Changed files

| File | What changed |
|---|---|
| `packages/core/src/config/schema/proxy.ts` | `DEFAULT_PROXY_PROXY_SUBTITLES` and `FORCE_PROXY_PROXY_SUBTITLES` env vars added to `default` and `force` sections |
| `packages/core/src/db/schemas.ts` | `proxySubtitles` added to `StatusResponseSchema` `forced.proxy` and `defaults.proxy` shapes |
| `packages/server/src/routes/api/status.ts` | `proxySubtitles` included in the `/api/status` forced/defaults proxy objects |
| `packages/core/src/main/resources.ts` | `proxifySubtitleUrls()` helper wired into `getSubtitles()` — encrypts auth+URL with same scheme as stream proxy, skips URLs already on `baseUrl` |
| `packages/frontend/src/context/userData.tsx` | forced/defaults merging picks up `proxySubtitles` same as `proxiedServices` |
| `packages/frontend/src/components/menu/proxy.tsx` | **Proxy Subtitles** Switch added to the Pro-mode Proxy Controls card, with force-disable support |

## Test plan

- [ ] Build passes: `pnpm build`
- [ ] Start the server with a Submaker addon configured (internal URL e.g. `http://submaker:7001/...`)
- [ ] Enable **Proxy** → toggle **Proxy Subtitles** in the configurator UI (Pro mode)
- [ ] Verify subtitle response URLs are rewritten to `https://<your-domain>/api/v1/proxy/e.<auth>.<data>/subtitle`
- [ ] Verify Stremio can fetch subtitles via the proxy URL
- [ ] Set `FORCE_PROXY_PROXY_SUBTITLES=true` env var; verify the toggle is disabled/forced in the UI and subtitles are always proxied
- [ ] Set `DEFAULT_PROXY_PROXY_SUBTITLES=true` env var; verify new users get the toggle pre-enabled