### PR TITLE
feat(subtitles): proxy subtitle URLs through the configured proxy

### DIFF
--- a/packages/core/src/main/resources.ts
+++ b/packages/core/src/main/resources.ts
@@ -12,6 +12,7 @@ import { Wrapper } from './wrapper.js';
 import { PresetManager } from '../presets/index.js';
 import { FeatureControl } from '../utils/feature.js';
 import { StreamContext, StreamUtils } from '../streams/index.js';
+import { createProxy } from '../proxy/index.js';
 import { populateNzbFallbacks } from './nzbFailover.js';
 import { resolveServiceWrappedStreams } from './serviceWrapper.js';
 import type { ServiceWrapServiceTiming } from './serviceWrapper.js';
@@ -967,6 +968,23 @@ export async function getSubtitles(
       }
     })
   );
+
+  if (ctx.userData.proxy?.enabled && allSubtitles.length > 0) {
+    try {
+      const proxy = createProxy(ctx.userData.proxy);
+      const proxiedUrls = await proxy.generateUrls(
+        allSubtitles.map((s) => ({ url: s.url, filename: 'subtitle' }))
+      );
+      if (proxiedUrls && !('error' in proxiedUrls)) {
+        allSubtitles = allSubtitles.map((s, i) => ({
+          ...s,
+          url: proxiedUrls[i] ?? s.url,
+        }));
+      }
+    } catch (err) {
+      logger.warn({ err }, 'failed to proxy subtitle urls');
+    }
+  }
 
   return { success: true, data: allSubtitles, errors };
 }


### PR DESCRIPTION
## Summary

- When the user's proxy is **enabled**, subtitle URLs are now passed through the same proxy (builtin, MediaFlow, StremThru) as stream URLs
- No new config, env vars, UI, or schema — controlled by the existing proxy settings
- Fixes internally-hosted subtitle services (e.g. `http://submaker:7001/...`) being unreachable by Stremio when AIOStreams is used with a proxy

## Change

Single block added to `getSubtitles()` in `packages/core/src/main/resources.ts`:

```ts
if (ctx.userData.proxy?.enabled && allSubtitles.length > 0) {
  const proxy = createProxy(ctx.userData.proxy);
  const proxiedUrls = await proxy.generateUrls(
    allSubtitles.map((s) => ({ url: s.url, filename: 'subtitle' }))
  );
  if (proxiedUrls && !('error' in proxiedUrls)) {
    allSubtitles = allSubtitles.map((s, i) => ({ ...s, url: proxiedUrls[i] ?? s.url }));
  }
}
```

## Test plan

- [ ] Configure a proxy (builtin recommended) in the addon configurator
- [ ] Add an addon that serves subtitles via an internal hostname (e.g. `http://submaker:7001/...`)
- [ ] Verify subtitle URLs in the Stremio response are rewritten through the proxy
- [ ] Verify Stremio can play subtitles
- [ ] Verify subtitle URLs are unchanged when proxy is disabled