### PR TITLE
feat(screener): community-shareable filter for dead and fake releases

### DIFF
--- a/packages/core/src/builtins/base/debrid.ts
+++ b/packages/core/src/builtins/base/debrid.ts
@@ -740,6 +740,7 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
             nzb: torrentOrNzb.nzb,
             title: torrentOrNzb.title,
             hash: torrentOrNzb.hash,
+            screenerKey: torrentOrNzb.screenerKey,
             index: torrentOrNzb.file.index,
             easynewsUrl:
               torrentOrNzb.service?.id === 'easynews'
@@ -785,6 +786,8 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
             )
           : undefined,
       nzbUrl: torrentOrNzb.type === 'usenet' ? torrentOrNzb.nzb : undefined,
+      screenerKey:
+        torrentOrNzb.type === 'usenet' ? torrentOrNzb.screenerKey : undefined,
       servers:
         torrentOrNzb.service?.id === 'stremio_nntp'
           ? (encryptedStoreAuth as string[])

--- a/packages/core/src/builtins/newznab/addon.ts
+++ b/packages/core/src/builtins/newznab/addon.ts
@@ -9,6 +9,8 @@ import {
 } from '../../debrid/index.js';
 import { SearchMetadata } from '../base/debrid.js';
 import { hashNzbUrl } from '../../debrid/utils.js';
+import { usenetKey } from '../../screener/key.js';
+import { toUnixSeconds } from '../../screener/fingerprint.js';
 import { BaseNabApi, SearchResultItem } from '../base/nab/api.js';
 import {
   BaseNabAddon,
@@ -208,6 +210,23 @@ export class NewznabAddon extends BaseNabAddon<NewznabAddonConfig, NewznabApi> {
       if (zyclopsHealth) {
         nzb.zyclopsHealth = zyclopsHealth;
       }
+
+      // Davex-compatible Screener key from the indexer's size/poster/date, so
+      // this release can be matched against shared dead-release lists.
+      const poster =
+        result.newznab?.poster == null
+          ? undefined
+          : String(result.newznab.poster).trim() || undefined;
+      // Hash the exact indexer-reported size, not the enclosure-length/0
+      // fallback nzb.size can hold, so the wd1 matches across indexers + davex.
+      const rawReleaseSize = result.size ?? result.newznab?.size;
+      const releaseSize =
+        rawReleaseSize == null ? undefined : Number(rawReleaseSize);
+      const screenerKey =
+        typeof releaseSize === 'number' && Number.isFinite(releaseSize)
+          ? usenetKey(releaseSize, poster, toUnixSeconds(date))
+          : null;
+      if (screenerKey) nzb.screenerKey = screenerKey;
 
       nzbs.push(nzb);
     }

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -26,6 +26,7 @@ export {
   type UsenetProviderRollup,
   type UsenetMetricBucket,
 } from './repositories/usenet-metrics.js';
+export { ScreenerStore } from './repositories/screener.js';
 export * from './schemas.js';
 
 export { sql, raw, join, SqlFragment } from './sql.js';

--- a/packages/core/src/db/migrations/0012_screener.ts
+++ b/packages/core/src/db/migrations/0012_screener.ts
@@ -1,0 +1,116 @@
+import type { Migration } from './types.js';
+
+/**
+ * Screener: aiostreams' community-shareable filter of bad releases. Two tables,
+ * both instance-global (one shared store per instance; per-user toggles live in
+ * UserData):
+ *
+ *   screener_sources  configured lists a verdict can come from. Always seeded
+ *                     with the 'local' source, which auto-fills from this
+ *                     instance's own playback failures / STAT dead-aborts.
+ *                     Remote sources are URL subscriptions; imported sources are
+ *                     one-off file imports. trust = full | corroborate | observe.
+ *
+ *   screener_entries  one verdict per (source, release key). `k` is a
+ *                     self-describing release key (`btih:<hash>` for torrents,
+ *                     `wd1:<fingerprint>` for usenet, the latter
+ *                     wire-compatible with nzbdavex). `kind` is derived from the
+ *                     prefix so usenet entries can be exported in davex format
+ *                     and torrent/usenet filtering can be scoped independently.
+ *
+ * Unix-second columns use sqlite INTEGER (64-bit) / postgres BIGINT to stay
+ * 2038-safe.
+ */
+export const screener: Migration = {
+  id: 12,
+  name: 'screener',
+  up: {
+    sqlite: `
+      CREATE TABLE IF NOT EXISTS screener_sources (
+        id            TEXT PRIMARY KEY,
+        kind          TEXT NOT NULL,
+        name          TEXT NOT NULL,
+        url           TEXT,
+        enabled       INTEGER NOT NULL DEFAULT 1,
+        trust         TEXT NOT NULL DEFAULT 'corroborate',
+        refresh_hours INTEGER NOT NULL DEFAULT 24,
+        last_checked  INTEGER NOT NULL DEFAULT 0,
+        last_updated  INTEGER NOT NULL DEFAULT 0,
+        etag          TEXT,
+        status        TEXT,
+        sort          INTEGER NOT NULL DEFAULT 0,
+        CHECK (kind IN ('local', 'remote', 'imported')),
+        CHECK (enabled IN (0, 1)),
+        CHECK (trust IN ('full', 'corroborate', 'observe')),
+        CHECK (refresh_hours > 0),
+        CHECK (kind <> 'remote' OR (url IS NOT NULL AND url <> ''))
+      );
+
+      CREATE TABLE IF NOT EXISTS screener_entries (
+        source_id TEXT NOT NULL REFERENCES screener_sources(id) ON DELETE CASCADE,
+        k         TEXT NOT NULL,
+        kind      TEXT NOT NULL,
+        verdict   TEXT NOT NULL,
+        n         INTEGER NOT NULL DEFAULT 1,
+        last_at   INTEGER NOT NULL DEFAULT 0,
+        backbones TEXT NOT NULL DEFAULT '',
+        PRIMARY KEY (source_id, k),
+        CHECK ((kind = 'torrent' AND k LIKE 'btih:%') OR (kind = 'usenet' AND k LIKE 'wd1:%')),
+        CHECK (verdict IN ('dead', 'fake', 'mislabeled')),
+        CHECK (n >= 0),
+        CHECK (last_at >= 0)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_screener_entries_k
+        ON screener_entries (k);
+
+      INSERT OR IGNORE INTO screener_sources
+        (id, kind, name, url, enabled, trust, refresh_hours)
+        VALUES ('local', 'local', 'This instance', NULL, 1, 'full', 24);
+    `,
+    postgres: `
+      CREATE TABLE IF NOT EXISTS screener_sources (
+        id            TEXT PRIMARY KEY,
+        kind          TEXT NOT NULL,
+        name          TEXT NOT NULL,
+        url           TEXT,
+        enabled       INTEGER NOT NULL DEFAULT 1,
+        trust         TEXT NOT NULL DEFAULT 'corroborate',
+        refresh_hours INTEGER NOT NULL DEFAULT 24,
+        last_checked  BIGINT NOT NULL DEFAULT 0,
+        last_updated  BIGINT NOT NULL DEFAULT 0,
+        etag          TEXT,
+        status        TEXT,
+        sort          INTEGER NOT NULL DEFAULT 0,
+        CHECK (kind IN ('local', 'remote', 'imported')),
+        CHECK (enabled IN (0, 1)),
+        CHECK (trust IN ('full', 'corroborate', 'observe')),
+        CHECK (refresh_hours > 0),
+        CHECK (kind <> 'remote' OR (url IS NOT NULL AND url <> ''))
+      );
+
+      CREATE TABLE IF NOT EXISTS screener_entries (
+        source_id TEXT NOT NULL REFERENCES screener_sources(id) ON DELETE CASCADE,
+        k         TEXT NOT NULL,
+        kind      TEXT NOT NULL,
+        verdict   TEXT NOT NULL,
+        n         BIGINT NOT NULL DEFAULT 1,
+        last_at   BIGINT NOT NULL DEFAULT 0,
+        backbones TEXT NOT NULL DEFAULT '',
+        PRIMARY KEY (source_id, k),
+        CHECK ((kind = 'torrent' AND k LIKE 'btih:%') OR (kind = 'usenet' AND k LIKE 'wd1:%')),
+        CHECK (verdict IN ('dead', 'fake', 'mislabeled')),
+        CHECK (n >= 0),
+        CHECK (last_at >= 0)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_screener_entries_k
+        ON screener_entries (k);
+
+      INSERT INTO screener_sources
+        (id, kind, name, url, enabled, trust, refresh_hours)
+        VALUES ('local', 'local', 'This instance', NULL, 1, 'full', 24)
+        ON CONFLICT (id) DO NOTHING;
+    `,
+  },
+};

--- a/packages/core/src/db/migrations/index.ts
+++ b/packages/core/src/db/migrations/index.ts
@@ -9,6 +9,7 @@ import { usenetMetrics } from './0008_usenet_metrics.js';
 import { usenetLibraryExt } from './0009_usenet_library_ext.js';
 import { usenetLibraryPassword } from './0010_usenet_library_password.js';
 import { usenetSpeed } from './0011_usenet_speed.js';
+import { screener } from './0012_screener.js';
 import type { Migration } from './types.js';
 
 export const MIGRATIONS: readonly Migration[] = [
@@ -23,6 +24,7 @@ export const MIGRATIONS: readonly Migration[] = [
   usenetLibraryExt,
   usenetLibraryPassword,
   usenetSpeed,
+  screener,
 ];
 
 export type { Migration } from './types.js';

--- a/packages/core/src/db/repositories/screener.sql.test.ts
+++ b/packages/core/src/db/repositories/screener.sql.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import Database from 'better-sqlite3';
+import { screener } from '../migrations/0012_screener.js';
+import { evaluateKey, type SourceVerdict } from '../../screener/evaluate.js';
+import { dedupeRecords } from '../../screener/io.js';
+import { N_CAP, type ScreenerRecord } from '../../screener/types.js';
+
+/**
+ * Validates the exact SQL ScreenerStore emits against a real sqlite engine. The
+ * store itself can't be imported here (it pulls db.js -> logger, a module-graph
+ * cycle that only resolves from the app entry), so these statements mirror the
+ * store's; keep them in sync. The export merge is the store's real `dedupeRecords`
+ * run over raw rows, so that half can't drift. End-to-end store coverage happens
+ * at app runtime.
+ */
+
+const DB_PATH = `${tmpdir()}/screener-sql-${process.pid}.db`;
+const TORRENT = 'btih:' + 'a'.repeat(40);
+const USENET = 'wd1:' + 'b'.repeat(32);
+
+let db: Database.Database;
+
+const SEV = `CASE %COL% WHEN 'fake' THEN 3 WHEN 'dead' THEN 2 WHEN 'mislabeled' THEN 1 ELSE 0 END`;
+const sev = (col: string) => SEV.replace('%COL%', col);
+
+// Mirrors ScreenerStore.markVerdict: a single atomic upsert, all merges computed
+// against the live row (no stale pre-read).
+const MARK = `
+  INSERT INTO screener_entries (source_id, k, kind, verdict, n, last_at, backbones)
+  VALUES (?, ?, ?, ?, 1, ?, ?)
+  ON CONFLICT (source_id, k) DO UPDATE SET
+    verdict = CASE WHEN (${sev('excluded.verdict')}) >= (${sev('verdict')})
+                   THEN excluded.verdict ELSE verdict END,
+    n = CASE WHEN n + 1 > ${N_CAP} THEN ${N_CAP} ELSE n + 1 END,
+    last_at = CASE WHEN excluded.last_at > last_at THEN excluded.last_at ELSE last_at END,
+    backbones = CASE
+      WHEN backbones = '' OR excluded.backbones = '' THEN ''
+      WHEN backbones = excluded.backbones THEN backbones
+      ELSE backbones || ',' || excluded.backbones END`;
+
+// Mirrors ScreenerStore.bulkUpsert.
+const BULK = `
+  INSERT INTO screener_entries (source_id, k, kind, verdict, n, last_at, backbones)
+  VALUES (?, ?, ?, ?, ?, ?, ?)
+  ON CONFLICT (source_id, k) DO UPDATE SET
+    verdict = CASE WHEN (${sev('excluded.verdict')}) >= (${sev('verdict')})
+                   THEN excluded.verdict ELSE verdict END,
+    n = CASE WHEN n + excluded.n > ${N_CAP} THEN ${N_CAP} ELSE n + excluded.n END,
+    last_at = CASE WHEN excluded.last_at > last_at THEN excluded.last_at ELSE last_at END,
+    backbones = CASE
+      WHEN backbones = '' OR excluded.backbones = '' THEN ''
+      WHEN backbones = excluded.backbones THEN backbones
+      ELSE backbones || ',' || excluded.backbones END`;
+
+const JOIN = `
+  SELECT e.k AS k, e.verdict AS verdict, e.backbones AS backbones, s.id AS source_id, s.trust AS trust
+  FROM screener_entries e JOIN screener_sources s ON s.id = e.source_id
+  WHERE e.k = ? AND s.enabled = 1 AND s.trust IN ('full', 'corroborate')`;
+
+function rowsFor(key: string): SourceVerdict[] {
+  return db
+    .prepare(JOIN)
+    .all(key)
+    .map((r: any) => ({
+      isLocal: r.source_id === 'local',
+      trust: r.trust,
+      verdict: r.verdict,
+      backbones: r.backbones ? String(r.backbones).split(',').filter(Boolean) : [],
+    }));
+}
+
+// Mirrors ScreenerStore.getEntries(..., true): raw select -> records -> the real
+// dedupeRecords, so the export merge under test is the live code, not a copy.
+function exportRecords(ids: string[]): ScreenerRecord[] {
+  const inList = ids.map(() => '?').join(',');
+  const rows = db
+    .prepare(
+      `SELECT k, verdict, last_at, n, backbones FROM screener_entries WHERE source_id IN (${inList})`
+    )
+    .all(...ids);
+  const records = rows
+    .filter((r: any) => ['dead', 'fake', 'mislabeled'].includes(r.verdict))
+    .map((r: any): ScreenerRecord => {
+      const bk = r.backbones ? String(r.backbones).split(',').filter(Boolean) : [];
+      return {
+        k: r.k,
+        v: r.verdict,
+        n: Number(r.n),
+        at: Number(r.last_at),
+        ...(bk.length ? { bk } : {}),
+      };
+    });
+  return dedupeRecords(records);
+}
+
+function addSrc(id: string, trust = 'corroborate'): void {
+  db.prepare(
+    `INSERT INTO screener_sources (id, kind, name, url, enabled, trust, refresh_hours)
+     VALUES (?, 'remote', ?, ?, 1, ?, 24)`
+  ).run(id, id, `https://example.test/${id}`, trust);
+}
+
+const OPTS = { quorum: 2, backboneScope: false, myBackbones: [] as string[] };
+
+before(() => {
+  db = new Database(DB_PATH);
+  db.pragma('foreign_keys = ON');
+  db.exec(screener.up.sqlite);
+});
+after(() => {
+  db.close();
+  for (const s of ['', '-wal', '-shm']) {
+    try {
+      rmSync(DB_PATH + s);
+    } catch {
+      /* ignore */
+    }
+  }
+});
+// Reset to the freshly-migrated state before each case so tests are independent
+// and order-free. Entries first to respect the FK.
+beforeEach(() => {
+  db.exec(`DELETE FROM screener_entries; DELETE FROM screener_sources WHERE id != 'local';`);
+});
+
+describe('migration DDL', () => {
+  it('seeds the local full-trust source', () => {
+    const row: any = db
+      .prepare(`SELECT kind, trust FROM screener_sources WHERE id = 'local'`)
+      .get();
+    assert.equal(row.kind, 'local');
+    assert.equal(row.trust, 'full');
+  });
+});
+
+describe('mark upsert (local auto-fill)', () => {
+  const at = 1719705600;
+
+  it('upgrades to the more severe verdict and bumps the count', () => {
+    db.prepare(MARK).run('local', TORRENT, 'torrent', 'dead', at, '');
+    db.prepare(MARK).run('local', TORRENT, 'torrent', 'fake', at, '');
+    const row: any = db
+      .prepare(`SELECT verdict, n FROM screener_entries WHERE source_id='local' AND k=?`)
+      .get(TORRENT);
+    assert.equal(row.verdict, 'fake'); // fake(3) >= dead(2)
+    assert.equal(row.n, 2);
+  });
+
+  it('never downgrades an already-stronger verdict', () => {
+    db.prepare(MARK).run('local', TORRENT, 'torrent', 'fake', at, '');
+    db.prepare(MARK).run('local', TORRENT, 'torrent', 'dead', at, '');
+    const row: any = db
+      .prepare(`SELECT verdict FROM screener_entries WHERE source_id='local' AND k=?`)
+      .get(TORRENT);
+    assert.equal(row.verdict, 'fake'); // dead(2) < fake(3), so it stays
+  });
+
+  it('keeps a global verdict global when re-marked with a scope', () => {
+    db.prepare(MARK).run('local', USENET, 'usenet', 'dead', at, ''); // global
+    db.prepare(MARK).run('local', USENET, 'usenet', 'dead', at, 'news.a.com');
+    const row: any = db
+      .prepare(`SELECT backbones FROM screener_entries WHERE source_id='local' AND k=?`)
+      .get(USENET);
+    assert.equal(row.backbones, '');
+  });
+
+  it("doesn't grow backbones when an unchanged scope is re-marked", () => {
+    db.prepare(MARK).run('local', USENET, 'usenet', 'dead', at, 'news.a.com');
+    db.prepare(MARK).run('local', USENET, 'usenet', 'dead', at, 'news.a.com');
+    const row: any = db
+      .prepare(`SELECT backbones FROM screener_entries WHERE source_id='local' AND k=?`)
+      .get(USENET);
+    assert.equal(row.backbones, 'news.a.com');
+  });
+
+  it('a local (full) verdict filters on its own', () => {
+    db.prepare(MARK).run('local', TORRENT, 'torrent', 'dead', at, '');
+    const v = evaluateKey(rowsFor(TORRENT), OPTS);
+    assert.equal(v.filtered, true);
+    assert.equal(v.verdict, 'dead');
+  });
+});
+
+describe('bulk upsert (import / remote) with severity CASE', () => {
+  it('keeps the more severe verdict and sums counts on conflict', () => {
+    addSrc('src_a');
+    db.prepare(BULK).run('src_a', USENET, 'usenet', 'mislabeled', 1, 1719705600, '');
+    db.prepare(BULK).run('src_a', USENET, 'usenet', 'dead', 2, 1719792000, '');
+    const row: any = db
+      .prepare(`SELECT verdict, n, last_at FROM screener_entries WHERE source_id='src_a' AND k=?`)
+      .get(USENET);
+    assert.equal(row.verdict, 'dead'); // dead(2) > mislabeled(1)
+    assert.equal(row.n, 3); // 1 + 2
+    assert.equal(row.last_at, 1719792000); // max
+  });
+
+  it('one corroborate source does not meet quorum 2', () => {
+    addSrc('src_a');
+    db.prepare(BULK).run('src_a', USENET, 'usenet', 'dead', 1, 1719705600, '');
+    assert.equal(evaluateKey(rowsFor(USENET), OPTS).filtered, false);
+  });
+
+  it('a second corroborate source meets quorum 2', () => {
+    addSrc('src_a');
+    addSrc('src_b');
+    db.prepare(BULK).run('src_a', USENET, 'usenet', 'dead', 1, 1719705600, '');
+    db.prepare(BULK).run('src_b', USENET, 'usenet', 'dead', 1, 1719705600, '');
+    assert.equal(evaluateKey(rowsFor(USENET), OPTS).filtered, true);
+  });
+});
+
+describe('dedup export (mirrors getEntries JS merge)', () => {
+  it('merges across sources: union backbones, sum counts, newest timestamp', () => {
+    addSrc('src_a');
+    addSrc('src_b');
+    db.prepare(BULK).run('src_a', USENET, 'usenet', 'dead', 3, 1719792000, 'news.a.com');
+    db.prepare(BULK).run('src_b', USENET, 'usenet', 'dead', 1, 1719705600, 'news.b.com');
+    const recs = exportRecords(['src_a', 'src_b']);
+    assert.equal(recs.length, 1);
+    assert.equal(recs[0].v, 'dead');
+    assert.equal(recs[0].n, 4); // 3 + 1
+    assert.equal(recs[0].at, 1719792000); // max
+    assert.deepEqual(recs[0].bk, ['news.a.com', 'news.b.com']);
+  });
+
+  it('stays global when any contributing source is unscoped', () => {
+    addSrc('src_a');
+    addSrc('src_b');
+    db.prepare(BULK).run('src_a', USENET, 'usenet', 'dead', 1, 1719705600, 'news.a.com');
+    db.prepare(BULK).run('src_b', USENET, 'usenet', 'dead', 1, 1719705600, ''); // global
+    const recs = exportRecords(['src_a', 'src_b']);
+    assert.equal(recs.length, 1);
+    assert.equal(recs[0].bk, undefined); // empty-bk means global, and global wins
+  });
+});

--- a/packages/core/src/db/repositories/screener.ts
+++ b/packages/core/src/db/repositories/screener.ts
@@ -1,0 +1,465 @@
+import { randomUUID } from 'node:crypto';
+import { getDb } from '../db.js';
+import { sql, raw, join, type SqlFragment } from '../sql.js';
+import { createLogger } from '../../logging/logger.js';
+import { keyKind } from '../../screener/key.js';
+import { evaluateKey, type SourceVerdict } from '../../screener/evaluate.js';
+import { dedupeRecords } from '../../screener/io.js';
+import {
+  LOCAL_SOURCE_ID,
+  N_CAP,
+  isVerdict,
+  normaliseTrust,
+  type ScreenerEvalOptions,
+  type ScreenerRecord,
+  type ScreenerSource,
+  type ScreenerVerdict,
+  type SourceKind,
+  type Trust,
+  type Verdict,
+} from '../../screener/types.js';
+
+const logger = createLogger('screener-store');
+
+const nowSec = (): number => Math.floor(Date.now() / 1000);
+const KEY_CHUNK = 500;
+
+/** SQL `CASE` mapping a verdict column to its severity (fake > dead > mislabeled). */
+function severity(col: string): SqlFragment {
+  return raw(
+    `CASE ${col} WHEN 'fake' THEN 3 WHEN 'dead' THEN 2 WHEN 'mislabeled' THEN 1 ELSE 0 END`
+  );
+}
+
+function csvToList(csv: unknown): string[] {
+  if (typeof csv !== 'string' || csv === '') return [];
+  return [
+    ...new Set(
+      csv
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s !== '')
+    ),
+  ];
+}
+
+function mergeCsv(existing: unknown, add: readonly string[]): string {
+  const set = new Set(csvToList(existing));
+  for (const b of add) {
+    const t = b.trim();
+    if (t !== '') set.add(t);
+  }
+  return [...set].join(',');
+}
+
+interface EntryJoinRow {
+  k: string;
+  verdict: string;
+  backbones: string | null;
+  source_id: string;
+  trust: string;
+  [col: string]: unknown;
+}
+
+interface SourceRow {
+  id: string;
+  kind: string;
+  name: string;
+  url: string | null;
+  enabled: number;
+  trust: string;
+  refresh_hours: number;
+  last_checked: number;
+  last_updated: number;
+  status: string | null;
+  count: number;
+  [col: string]: unknown;
+}
+
+/**
+ * Instance-global store behind the Screener feature: the dead/fake/mislabeled
+ * release verdicts and the sources they come from. Per-user filtering knobs
+ * (quorum, backbone scope) are passed in per call, not read from here.
+ */
+export class ScreenerStore {
+  // --- presence cache -------------------------------------------------------
+  // Lets the request-path filter skip all work on instances with an empty store
+  // without a query per request. Invalidated whenever entries change.
+  private static presence: { at: number; value: boolean } | null = null;
+  private static readonly PRESENCE_TTL_MS = 30_000;
+
+  /** Cheap, cached check for whether the store holds any entries at all. */
+  static async hasEntries(): Promise<boolean> {
+    const now = Date.now();
+    if (this.presence && now - this.presence.at < this.PRESENCE_TTL_MS) {
+      return this.presence.value;
+    }
+    try {
+      const total = await getDb().count(
+        sql`SELECT COUNT(*) FROM screener_entries`
+      );
+      this.presence = { at: now, value: total > 0 };
+      return this.presence.value;
+    } catch (err) {
+      // Never cache a DB-error "empty": a transient blip would otherwise disable
+      // filtering for the whole TTL. Fall back to the last known value.
+      logger.debug(`screener presence check failed: ${err}`);
+      return this.presence?.value ?? false;
+    }
+  }
+
+  private static invalidatePresence(): void {
+    this.presence = null;
+  }
+
+  // --- auto-fill (local source) ---------------------------------------------
+
+  /**
+   * Record a verdict for a release on the local source. Idempotent-ish: repeat
+   * calls bump the count, keep the most severe verdict, and union backbones.
+   */
+  static async markVerdict(
+    key: string,
+    verdict: Verdict,
+    backbones: readonly string[] = []
+  ): Promise<void> {
+    const kind = keyKind(key);
+    if (!kind || !isVerdict(verdict)) return;
+    // Empty backbones == "global" (applies on any backbone); a fresh mark adopts
+    // ours, or '' when this instance has none.
+    const addCsv = mergeCsv('', backbones);
+    const at = nowSec();
+    const db = getDb();
+    try {
+      // Single atomic upsert: the verdict/count/backbone merge happens in the
+      // DO UPDATE against the live row, so racing marks can't downgrade a
+      // stronger verdict or re-narrow a global backbone set from a stale read.
+      // Backbones stay global if either side is global, and don't grow when an
+      // unchanged scope is re-marked.
+      await db.exec(
+        sql`INSERT INTO screener_entries
+              (source_id, k, kind, verdict, n, last_at, backbones)
+            VALUES (${LOCAL_SOURCE_ID}, ${key}, ${kind}, ${verdict}, 1, ${at}, ${addCsv})
+            ON CONFLICT (source_id, k) DO UPDATE SET
+              verdict = CASE WHEN (${severity('excluded.verdict')}) >= (${severity('verdict')})
+                             THEN excluded.verdict ELSE verdict END,
+              n = ${raw('CASE WHEN n + 1 > ' + N_CAP + ' THEN ' + N_CAP + ' ELSE n + 1 END')},
+              last_at = ${raw('CASE WHEN excluded.last_at > last_at THEN excluded.last_at ELSE last_at END')},
+              backbones = CASE
+                WHEN backbones = '' OR excluded.backbones = '' THEN ''
+                WHEN backbones = excluded.backbones THEN backbones
+                ELSE backbones || ',' || excluded.backbones END`
+      );
+      ScreenerStore.invalidatePresence();
+    } catch (err) {
+      // Auto-mark callers are fire-and-forget (they .catch); the /mark route
+      // awaits, so surface the failure instead of reporting a fake success.
+      logger.debug(`screener mark failed: ${err}`);
+      throw err;
+    }
+  }
+
+  // --- filtering ------------------------------------------------------------
+
+  /**
+   * Evaluate a batch of release keys against all enabled sources. Returns a map
+   * of key -> verdict for every key that had at least one contributing source
+   * row; keys absent from the map are not flagged. `.filtered` says whether the
+   * caller should actually hide it.
+   */
+  static async evaluateKeys(
+    keys: readonly string[],
+    opts: ScreenerEvalOptions
+  ): Promise<Map<string, ScreenerVerdict>> {
+    const out = new Map<string, ScreenerVerdict>();
+    const unique = [...new Set(keys.filter((k) => keyKind(k) !== null))];
+    if (unique.length === 0) return out;
+    const db = getDb();
+
+    for (let i = 0; i < unique.length; i += KEY_CHUNK) {
+      const slice = unique.slice(i, i + KEY_CHUNK);
+      const inList = join(slice.map((k) => sql`${k}`));
+      // Let a query failure propagate. The request-path caller (applyScreener)
+      // fails open as a whole; swallowing here would instead make this chunk's
+      // keys look clean and let flagged releases through silently.
+      const rows = await db.query<EntryJoinRow>(
+        sql`SELECT e.k AS k, e.verdict AS verdict, e.backbones AS backbones,
+                   s.id AS source_id, s.trust AS trust
+            FROM screener_entries e
+            JOIN screener_sources s ON s.id = e.source_id
+            WHERE e.k IN (${inList})
+              AND s.enabled = 1
+              AND s.trust IN ('full', 'corroborate')`
+      );
+
+      const byKey = new Map<string, SourceVerdict[]>();
+      for (const r of rows) {
+        if (!isVerdict(r.verdict)) continue;
+        const list = byKey.get(r.k) ?? [];
+        list.push({
+          isLocal: r.source_id === LOCAL_SOURCE_ID,
+          trust: normaliseTrust(r.trust),
+          verdict: r.verdict,
+          backbones: csvToList(r.backbones),
+        });
+        byKey.set(r.k, list);
+      }
+      for (const [k, list] of byKey) {
+        out.set(k, evaluateKey(list, opts));
+      }
+    }
+    return out;
+  }
+
+  // --- counts ---------------------------------------------------------------
+
+  static async getCounts(): Promise<{ total: number; local: number }> {
+    const db = getDb();
+    const total = await db.count(sql`SELECT COUNT(*) FROM screener_entries`);
+    const local = await db.count(
+      sql`SELECT COUNT(*) FROM screener_entries WHERE source_id = ${LOCAL_SOURCE_ID}`
+    );
+    return { total, local };
+  }
+
+  // --- sources --------------------------------------------------------------
+
+  static async getSources(): Promise<ScreenerSource[]> {
+    const db = getDb();
+    const rows = await db.query<SourceRow>(
+      sql`SELECT s.id, s.kind, s.name, s.url, s.enabled, s.trust, s.refresh_hours,
+                 s.last_checked, s.last_updated, s.status,
+                 (SELECT COUNT(*) FROM screener_entries e WHERE e.source_id = s.id) AS count
+          FROM screener_sources s
+          ORDER BY CASE WHEN s.id = ${LOCAL_SOURCE_ID} THEN 0 ELSE 1 END, s.sort, s.name`
+    );
+    return rows.map(rowToSource);
+  }
+
+  static async addSource(
+    kind: Exclude<SourceKind, 'local'>,
+    name: string,
+    url: string | null,
+    trust: Trust,
+    refreshHours: number
+  ): Promise<string> {
+    const trimmedUrl = url?.trim() || null;
+    if (kind === 'remote' && !trimmedUrl) {
+      throw new Error('A remote source requires a URL.');
+    }
+    const id = 'src_' + randomUUID().replace(/-/g, '').slice(0, 12);
+    const db = getDb();
+    await db.exec(
+      sql`INSERT INTO screener_sources
+            (id, kind, name, url, enabled, trust, refresh_hours, last_checked, last_updated, status, sort)
+          VALUES (${id}, ${kind}, ${name.trim() || 'Untitled'}, ${trimmedUrl},
+                  1, ${normaliseTrust(trust)}, ${clampRefreshHours(refreshHours)}, 0, 0, NULL,
+                  ${raw('(SELECT COALESCE(MAX(sort), 0) + 1 FROM screener_sources)')})`
+    );
+    return id;
+  }
+
+  static async updateSource(
+    id: string,
+    fields: {
+      enabled?: boolean;
+      trust?: Trust;
+      refreshHours?: number;
+      name?: string;
+    }
+  ): Promise<void> {
+    if (id === LOCAL_SOURCE_ID) return;
+    const sets: SqlFragment[] = [];
+    if (fields.enabled !== undefined)
+      sets.push(sql`enabled = ${fields.enabled ? 1 : 0}`);
+    if (fields.trust !== undefined)
+      sets.push(sql`trust = ${normaliseTrust(fields.trust)}`);
+    if (fields.refreshHours !== undefined)
+      sets.push(sql`refresh_hours = ${clampRefreshHours(fields.refreshHours)}`);
+    if (fields.name !== undefined)
+      sets.push(sql`name = ${fields.name.trim() || 'Untitled'}`);
+    if (sets.length === 0) return;
+    await getDb().exec(
+      sql`UPDATE screener_sources SET ${join(sets)} WHERE id = ${id}`
+    );
+  }
+
+  /** Delete a non-local source and its entries. Returns false for 'local'. */
+  static async removeSource(id: string): Promise<boolean> {
+    if (id === LOCAL_SOURCE_ID) return false;
+    const db = getDb();
+    await db.tx(async (tx) => {
+      await tx.exec(
+        sql`DELETE FROM screener_entries WHERE source_id = ${id}`
+      );
+      await tx.exec(sql`DELETE FROM screener_sources WHERE id = ${id}`);
+    });
+    ScreenerStore.invalidatePresence();
+    return true;
+  }
+
+  /** Empty a source's entries (keeps the source row). Returns rows removed. */
+  static async clearSource(id: string): Promise<number> {
+    const res = await getDb().exec(
+      sql`DELETE FROM screener_entries WHERE source_id = ${id}`
+    );
+    ScreenerStore.invalidatePresence();
+    return res.rowCount;
+  }
+
+  static async setSourceStatus(
+    id: string,
+    etag: string | null,
+    lastChecked: number,
+    lastUpdated: number,
+    status: string | null
+  ): Promise<void> {
+    await getDb().exec(
+      sql`UPDATE screener_sources
+          SET etag = ${etag}, last_checked = ${lastChecked},
+              last_updated = ${lastUpdated}, status = ${status}
+          WHERE id = ${id}`
+    );
+  }
+
+  static async touchChecked(
+    id: string,
+    when: number,
+    status: string | null
+  ): Promise<void> {
+    await getDb().exec(
+      sql`UPDATE screener_sources SET last_checked = ${when}, status = ${status} WHERE id = ${id}`
+    );
+  }
+
+  static async getSourceEtag(id: string): Promise<string | null> {
+    const row = await getDb().maybeOne<{ etag: string | null }>(
+      sql`SELECT etag FROM screener_sources WHERE id = ${id}`
+    );
+    return row?.etag ?? null;
+  }
+
+  // --- bulk import / export -------------------------------------------------
+
+  /**
+   * Upsert records into a source. With `replace`, the source's existing entries
+   * are cleared first. Invalid keys/verdicts are skipped. Returns rows written.
+   */
+  static async bulkUpsert(
+    sourceId: string,
+    records: readonly ScreenerRecord[],
+    opts: { replace?: boolean } = {}
+  ): Promise<number> {
+    const db = getDb();
+    const now = nowSec();
+    let written = 0;
+    const valid = records.filter((rec) => keyKind(rec.k) && isVerdict(rec.v));
+    // Block a replace whose payload had records but none survived validation (a
+    // garbage feed would otherwise wipe the source). An intentionally empty
+    // payload (no records at all) is allowed through to clear the source.
+    if (opts.replace && records.length > 0 && valid.length === 0) {
+      throw new Error('Refusing to replace a source with only invalid entries.');
+    }
+    await db.tx(async (tx) => {
+      if (opts.replace) {
+        await tx.exec(
+          sql`DELETE FROM screener_entries WHERE source_id = ${sourceId}`
+        );
+      }
+      for (const rec of valid) {
+        const kind = keyKind(rec.k)!;
+        const n =
+          Number.isFinite(rec.n) && rec.n > 0
+            ? Math.min(Math.trunc(rec.n), N_CAP)
+            : 1;
+        const at = Number.isFinite(rec.at)
+          ? Math.min(Math.max(Math.trunc(rec.at), 0), now + 86400)
+          : 0;
+        const bk = [
+          ...new Set((rec.bk ?? []).map((b) => b.trim()).filter((b) => b !== '')),
+        ].join(',');
+        await tx.exec(
+          sql`INSERT INTO screener_entries
+                (source_id, k, kind, verdict, n, last_at, backbones)
+              VALUES (${sourceId}, ${rec.k}, ${kind}, ${rec.v}, ${n}, ${at}, ${bk})
+              ON CONFLICT (source_id, k) DO UPDATE SET
+                verdict = CASE WHEN ${severity('excluded.verdict')} >= ${severity('verdict')}
+                               THEN excluded.verdict ELSE verdict END,
+                n = ${raw('CASE WHEN n + excluded.n > ' + N_CAP + ' THEN ' + N_CAP + ' ELSE n + excluded.n END')},
+                last_at = CASE WHEN excluded.last_at > last_at THEN excluded.last_at ELSE last_at END,
+                backbones = CASE
+                  WHEN backbones = '' OR excluded.backbones = '' THEN ''
+                  WHEN backbones = excluded.backbones THEN backbones
+                  ELSE backbones || ',' || excluded.backbones
+                END`
+        );
+        written++;
+      }
+    });
+    ScreenerStore.invalidatePresence();
+    return written;
+  }
+
+  /**
+   * Read entries for export. With `dedup`, same-key rows across the given
+   * sources are merged into one record: most severe verdict, summed n, latest
+   * timestamp, and unioned backbones. Backbones are preserved either way so the
+   * export round-trips back through import.
+   */
+  static async getEntries(
+    sourceIds: readonly string[],
+    dedup: boolean
+  ): Promise<ScreenerRecord[]> {
+    const ids = sourceIds.length === 0 ? [LOCAL_SOURCE_ID] : sourceIds;
+    const inList = join(ids.map((id) => sql`${id}`));
+    const db = getDb();
+    const rows = await db.query<{
+      k: string;
+      verdict: string;
+      last_at: number;
+      n: number;
+      backbones: string | null;
+    }>(
+      sql`SELECT k, verdict, last_at, n, backbones
+          FROM screener_entries WHERE source_id IN (${inList})`
+    );
+
+    const records = rows
+      .filter((r) => isVerdict(r.verdict))
+      .map((r): ScreenerRecord => {
+        const bk = csvToList(r.backbones);
+        return {
+          k: r.k,
+          v: r.verdict as Verdict,
+          n: Number(r.n),
+          at: Number(r.last_at),
+          ...(bk.length ? { bk } : {}),
+        };
+      });
+    if (!dedup) return records;
+    return dedupeRecords(records);
+  }
+}
+
+function rowToSource(r: SourceRow): ScreenerSource {
+  return {
+    id: r.id,
+    kind: (['local', 'remote', 'imported'].includes(r.kind)
+      ? r.kind
+      : 'imported') as SourceKind,
+    name: r.name,
+    url: r.url,
+    enabled: Number(r.enabled) !== 0,
+    trust: normaliseTrust(r.trust),
+    refreshHours: Number(r.refresh_hours),
+    lastChecked: Number(r.last_checked),
+    lastUpdated: Number(r.last_updated),
+    status: r.status,
+    count: Number(r.count),
+  };
+}
+
+function clampRefreshHours(hours: number): number {
+  if (!Number.isFinite(hours)) return 24;
+  return Math.min(Math.max(Math.trunc(hours), 1), 24 * 30);
+}

--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -275,6 +275,15 @@ const DeduplicatorOptions = z.object({
     .optional(),
 });
 
+// Per-user knobs for the Screener (the instance-global shared filter of bad
+// releases). Sources and their trust are operator-managed; these are the
+// per-user filtering controls.
+const ScreenerOptions = z.object({
+  enabled: z.boolean().optional(), // hide releases flagged dead/fake/mislabeled from my results
+  quorum: z.number().int().min(1).max(20).optional(), // agreements needed before a corroborate source filters
+  backboneScope: z.boolean().optional(), // only honour remote usenet verdicts whose provider matches mine
+});
+
 const OptionDefinition = z.looseObject({
   id: z.string().min(1),
   name: z.string(),
@@ -757,6 +766,7 @@ export const UserDataSchema = z.object({
     })
     .optional(),
   deduplicator: DeduplicatorOptions.optional(),
+  screener: ScreenerOptions.optional(),
   autoPlay: z
     .object({
       enabled: z.boolean().optional(),
@@ -945,9 +955,19 @@ export const NNTPServersSchema = z.array(NNTPServerSchema);
 
 export type NNTPServers = z.infer<typeof NNTPServersSchema>;
 
+// One contract for the Screener key at every stream boundary: only a valid
+// usenet `wd1:` key survives, anything else is dropped rather than rejecting the
+// whole stream.
+export const ScreenerKeySchema = z
+  .string()
+  .regex(/^wd1:[0-9a-f]{32}$/)
+  .optional()
+  .catch(undefined);
+
 export const StreamSchema = z.looseObject({
   url: z.string().or(z.null()).optional(),
   nzbUrl: z.string().or(z.null()).optional(),
+  screenerKey: ScreenerKeySchema,
   servers: z.array(z.string().min(1)).nullable().optional(),
   rarUrls: z.array(SourceSchema).nullable().optional(),
   zipUrls: z.array(SourceSchema).nullable().optional(),
@@ -1094,6 +1114,10 @@ export const ParsedStreamSchema = z.object({
   passthrough: PassthroughSchema.optional(),
   url: z.string().optional(),
   nzbUrl: z.string().optional(),
+  // Precomputed Screener release key (`wd1:...`) for usenet streams, set by the
+  // builtin that has the poster/date/size. Torrent/debrid keys are derived from
+  // `torrent.infoHash` at filter time and don't need this.
+  screenerKey: ScreenerKeySchema,
   // Same-release failover targets harvested from discarded duplicates by the
   // deduplicator merge step. Each is another playback URL for the *same*
   // release (a different indexer's NZB or another addon's debrid link).

--- a/packages/core/src/debrid/aiostreams.ts
+++ b/packages/core/src/debrid/aiostreams.ts
@@ -289,6 +289,7 @@ export class NativeUsenetService implements UsenetDebridService {
       fileIndex: selected.index,
       innerPath: selected.path,
       filename: chosenFilename,
+      screenerKey: playbackInfo.screenerKey,
     });
 
     const url = `${appConfig.bootstrap.baseUrl}/api/v1/usenet/stream/${token}/${encodeURIComponent(

--- a/packages/core/src/debrid/base.ts
+++ b/packages/core/src/debrid/base.ts
@@ -221,6 +221,14 @@ const UsenetInfoSchema = BaseFileInfoSchema.extend({
   hash: z.string(),
   easynewsUrl: z.string().optional(),
   nzb: z.string(),
+  // Davex-compatible Screener key (`wd1:...`) carried to playback so a release
+  // discovered dead (articles missing) can auto-mark itself on the Screener.
+  // Only valid usenet keys are accepted; anything else is dropped here.
+  screenerKey: z
+    .string()
+    .regex(/^wd1:[0-9a-f]{32}$/)
+    .optional()
+    .catch(undefined),
   type: z.literal('usenet'),
 });
 

--- a/packages/core/src/debrid/utils.ts
+++ b/packages/core/src/debrid/utils.ts
@@ -202,6 +202,8 @@ export interface NZB extends BaseFile {
   easynewsUrl?: string;
   zyclopsHealth?: string;
   serviceItemId?: string;
+  /** Screener release key (`wd1:...`) from the indexer's size/poster/date. */
+  screenerKey?: string;
 }
 
 export interface TorrentWithSelectedFile extends Torrent {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export * from './utils/index.js';
 export * from './logging/ring-buffer.js';
 export * from './config/index.js';
 export * from './db/index.js';
+export * from './screener/index.js';
 export * from './analytics/index.js';
 export * from './analytics/repository.js';
 export * from './tasks/index.js';

--- a/packages/core/src/main/failover.ts
+++ b/packages/core/src/main/failover.ts
@@ -93,6 +93,7 @@ function buildPlaybackInfo(
         title: fileInfo.title,
         hash: fileInfo.hash,
         nzb: fileInfo.nzb,
+        screenerKey: fileInfo.screenerKey,
         easynewsUrl: fileInfo.easynewsUrl,
         index: fileInfo.index,
         filename,

--- a/packages/core/src/main/resources.ts
+++ b/packages/core/src/main/resources.ts
@@ -289,6 +289,11 @@ export async function processStreams(
     filterMs = Date.now() - filterStart;
   }
 
+  // Drop releases the Screener has flagged (dead/fake/mislabeled) before dedup,
+  // so a flagged candidate never becomes a failover attempt. Recorded as a
+  // 'screener' filter reason so it shows in the per-request stats / dashboard.
+  processedStreams = await ctx.filterer.screenFlagged(processedStreams);
+
   const dedupStart = Date.now();
   processedStreams = await ctx.deduplicator.deduplicate(processedStreams);
   deduplicationMs = Date.now() - dedupStart;

--- a/packages/core/src/parser/streams.ts
+++ b/packages/core/src/parser/streams.ts
@@ -9,6 +9,7 @@ import {
 } from '../utils/index.js';
 import { config as appConfig } from '../config/index.js';
 import FileParser from './file.js';
+import { keyKind } from '../screener/key.js';
 import {
   parseAgeString,
   parseDuration,
@@ -88,6 +89,12 @@ class StreamParser {
       proxied: this.isProxied(stream),
       url: this.applyUrlModifications(stream.url ?? undefined),
       nzbUrl: stream.nzbUrl || undefined,
+      // Only carry a usenet (wd1) Screener key; ignore anything an addon injects
+      // that isn't a valid usenet key.
+      screenerKey:
+        keyKind(stream.screenerKey) === 'usenet'
+          ? (stream.screenerKey ?? undefined)
+          : undefined,
       tarUrls: stream.tarUrls ?? undefined,
       tgzUrls: stream.tgzUrls ?? undefined,
       '7zipUrls': stream['7zipUrls'] ?? undefined,

--- a/packages/core/src/screener/backbones.ts
+++ b/packages/core/src/screener/backbones.ts
@@ -1,0 +1,35 @@
+import { config as appConfig } from '../config/index.js';
+import { createLogger } from '../logging/logger.js';
+import { rootDomain } from './evaluate.js';
+
+const logger = createLogger('screener');
+
+/**
+ * The backbones (provider root domains) this instance streams from, derived
+ * from the enabled native Usenet providers. Used to scope shared dead-release
+ * verdicts to backbones we actually use, and recorded on our own verdicts so
+ * others can scope against them.
+ *
+ * Empty when no native providers are configured (e.g. debrid-only usenet),
+ * which leaves backbone scoping inert.
+ */
+export function myBackbones(): string[] {
+  try {
+    const providers = appConfig.usenet.providers as Array<{
+      host?: string;
+      enabled?: boolean;
+    }>;
+    const set = new Set<string>();
+    for (const p of providers) {
+      if (p.enabled === false) continue;
+      const root = rootDomain(p.host);
+      if (root !== 'unknown') set.add(root);
+    }
+    return [...set];
+  } catch (err) {
+    // Fail safe (no scoping) but surface it: silently empty backbones would
+    // quietly apply every remote verdict regardless of provider.
+    logger.warn(`could not derive backbones; scoping disabled: ${err}`);
+    return [];
+  }
+}

--- a/packages/core/src/screener/evaluate.test.ts
+++ b/packages/core/src/screener/evaluate.test.ts
@@ -1,0 +1,125 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { evaluateKey, rootDomain, type SourceVerdict } from './evaluate.js';
+import type { ScreenerEvalOptions } from './types.js';
+
+const OPTS = (over: Partial<ScreenerEvalOptions> = {}): ScreenerEvalOptions => ({
+  quorum: 2,
+  backboneScope: false,
+  myBackbones: [],
+  ...over,
+});
+
+const row = (over: Partial<SourceVerdict> = {}): SourceVerdict => ({
+  isLocal: false,
+  trust: 'corroborate',
+  verdict: 'dead',
+  backbones: [],
+  ...over,
+});
+
+describe('evaluateKey: trust + quorum', () => {
+  it('a full source filters on its own', () => {
+    const r = evaluateKey([row({ trust: 'full', isLocal: true })], OPTS());
+    assert.equal(r.filtered, true);
+    assert.equal(r.verdict, 'dead');
+    assert.equal(r.reason, 'dead');
+  });
+
+  it('one corroborate source does not meet quorum 2', () => {
+    assert.equal(evaluateKey([row()], OPTS()).filtered, false);
+  });
+
+  it('two corroborate sources meet quorum 2', () => {
+    const r = evaluateKey([row(), row()], OPTS());
+    assert.equal(r.filtered, true);
+    assert.equal(r.reason, 'dead (2 sources)');
+  });
+
+  it('observe sources never filter', () => {
+    assert.equal(
+      evaluateKey([row({ trust: 'observe' }), row({ trust: 'observe' })], OPTS())
+        .filtered,
+      false
+    );
+  });
+
+  it('surfaces the most severe verdict', () => {
+    const r = evaluateKey(
+      [row({ verdict: 'dead' }), row({ verdict: 'fake' })],
+      OPTS()
+    );
+    assert.equal(r.verdict, 'fake');
+  });
+});
+
+describe('evaluateKey: backbone scope', () => {
+  const scoped = OPTS({ backboneScope: true, myBackbones: ['news.myprovider.com'] });
+
+  it('excludes a remote verdict from a non-matching backbone', () => {
+    assert.equal(
+      evaluateKey(
+        [row({ trust: 'full', backbones: ['news.other.com'] })],
+        scoped
+      ).filtered,
+      false
+    );
+  });
+
+  it('honours a remote verdict whose backbone matches mine (root domain)', () => {
+    assert.equal(
+      evaluateKey(
+        [row({ trust: 'full', backbones: ['feed.myprovider.com'] })],
+        scoped
+      ).filtered,
+      true
+    );
+  });
+
+  it('treats a verdict with no backbones as in-scope', () => {
+    assert.equal(
+      evaluateKey([row({ trust: 'full', backbones: [] })], scoped).filtered,
+      true
+    );
+  });
+
+  it('treats a verdict with only unparseable backbones as applying everywhere', () => {
+    // No known backbones (all collapse to "unknown") means it applies anywhere,
+    // the same as an empty list.
+    assert.equal(
+      evaluateKey(
+        [row({ trust: 'full', backbones: ['', '   '] })],
+        scoped
+      ).filtered,
+      true
+    );
+  });
+
+  it('local verdicts always count regardless of scope', () => {
+    assert.equal(
+      evaluateKey(
+        [row({ isLocal: true, trust: 'full', backbones: ['news.other.com'] })],
+        scoped
+      ).filtered,
+      true
+    );
+  });
+});
+
+describe('rootDomain', () => {
+  it('reduces a host to its registrable root', () => {
+    assert.equal(rootDomain('news.example.com'), 'example.com');
+    assert.equal(rootDomain('example.com'), 'example.com');
+    assert.equal(rootDomain('a.b.co.uk'), 'b.co.uk');
+    assert.equal(rootDomain('news.example.com:563'), 'example.com');
+    assert.equal(rootDomain('1.2.3.4'), '1.2.3.4');
+    assert.equal(rootDomain(''), 'unknown');
+    assert.equal(rootDomain(null), 'unknown');
+  });
+
+  it('preserves IPv6 literals instead of truncating at the first colon', () => {
+    assert.equal(rootDomain('2001:db8::1'), '2001:db8::1');
+    assert.equal(rootDomain('[2001:db8::1]:563'), '2001:db8::1');
+    assert.equal(rootDomain('[::1]'), '::1');
+  });
+});

--- a/packages/core/src/screener/evaluate.ts
+++ b/packages/core/src/screener/evaluate.ts
@@ -1,0 +1,132 @@
+import type {
+  Trust,
+  Verdict,
+  ScreenerEvalOptions,
+  ScreenerVerdict,
+} from './types.js';
+import { moreSevere } from './types.js';
+
+/** One source's verdict on a single release, as fed to the evaluator. */
+export interface SourceVerdict {
+  /** True for the always-on local source (exempt from backbone scoping). */
+  isLocal: boolean;
+  trust: Trust;
+  verdict: Verdict;
+  /** Backbones / trackers that observed this verdict (for scoping). */
+  backbones: string[];
+}
+
+const IPV4 = /^(25[0-5]|2[0-4]\d|1?\d?\d)(\.(25[0-5]|2[0-4]\d|1?\d?\d)){3}$/;
+
+/**
+ * Collapse a host to its registrable root domain, e.g. `news.example.com` ->
+ * `example.com`, `a.b.co.uk` -> `b.co.uk`. Bare IPs pass through. Ported from
+ * nzbdavex's `WardenFingerprint.RootDomain` so backbone scoping agrees with it.
+ */
+export function rootDomain(host: string | null | undefined): string {
+  if (!host) return 'unknown';
+  let h = host.trim().toLowerCase();
+  // IPv6 literal: bracketed `[2001:db8::1]:563` or bare `2001:db8::1`. Keep the
+  // whole address; the first-colon port split below would otherwise truncate it.
+  if (h.startsWith('[')) {
+    const end = h.indexOf(']');
+    return end > 1 ? h.slice(1, end) : 'unknown';
+  }
+  if ((h.match(/:/g)?.length ?? 0) >= 2) return h;
+  const colon = h.indexOf(':');
+  if (colon > 0) h = h.slice(0, colon);
+  h = h.replace(/^\.+|\.+$/g, '');
+  if (h.length === 0) return 'unknown';
+  if (IPV4.test(h)) return h;
+
+  const labels = h.split('.').filter(Boolean);
+  if (labels.length <= 2) return h;
+  // A 2-char TLD with a short second level (e.g. co.uk, com.au) keeps 3 labels.
+  const tld = labels[labels.length - 1];
+  const sld = labels[labels.length - 2];
+  const take = tld.length === 2 && sld.length <= 3 ? 3 : 2;
+  return labels.slice(labels.length - take).join('.');
+}
+
+/**
+ * True if an entry applies to one of my backbones. Mirrors davex's
+ * BackboneInScope: an entry with no *known* backbones (empty, or all
+ * unparseable) applies everywhere; otherwise one of its backbones must overlap
+ * mine.
+ */
+function backboneInScope(
+  backbones: readonly string[],
+  myRoots: ReadonlySet<string>
+): boolean {
+  let known = false;
+  for (const b of backbones) {
+    const rb = rootDomain(b);
+    if (rb === 'unknown') continue;
+    known = true;
+    if (myRoots.has(rb)) return true;
+  }
+  return !known;
+}
+
+/**
+ * Reduce one release's per-source verdicts to a filter decision. Mirrors
+ * nzbdavex's trust + quorum + backbone-scope rules:
+ *  - `observe` sources never filter (kept for visibility only).
+ *  - a `full` source filters on its own.
+ *  - `corroborate` sources filter only once >= quorum of them agree.
+ *  - with backbone scope on (and at least one known local backbone), a
+ *    non-local source's verdict only counts when its backbones intersect mine,
+ *    or it records none.
+ *
+ * Callers should pass only rows from enabled sources; `observe` is tolerated
+ * here so the rule lives in one place.
+ */
+export function evaluateKey(
+  rows: readonly SourceVerdict[],
+  opts: ScreenerEvalOptions
+): ScreenerVerdict {
+  const quorum = Math.max(1, opts.quorum);
+  const myRoots = opts.backboneScope
+    ? new Set(
+        opts.myBackbones.map(rootDomain).filter((b) => b !== 'unknown')
+      )
+    : new Set<string>();
+  const scope = myRoots.size > 0;
+
+  let agree = 0;
+  let fullSource = false;
+  let fullVerdict: Verdict | null = null;
+  let corroborateVerdict: Verdict | null = null;
+
+  for (const row of rows) {
+    if (row.trust === 'observe') continue;
+    if (scope && !row.isLocal && !backboneInScope(row.backbones, myRoots)) {
+      continue;
+    }
+    if (row.trust === 'full') {
+      fullSource = true;
+      fullVerdict = fullVerdict
+        ? moreSevere(fullVerdict, row.verdict)
+        : row.verdict;
+    } else {
+      agree++;
+      corroborateVerdict = corroborateVerdict
+        ? moreSevere(corroborateVerdict, row.verdict)
+        : row.verdict;
+    }
+  }
+
+  const quorumMet = agree >= quorum;
+  const filtered = fullSource || quorumMet;
+  // Full sources always set the verdict; corroborate sources only contribute
+  // once they meet quorum, so a lone corroborator can't upgrade a verdict.
+  let verdict: Verdict | null = fullVerdict;
+  if (quorumMet && corroborateVerdict) {
+    verdict = verdict ? moreSevere(verdict, corroborateVerdict) : corroborateVerdict;
+  }
+  if (!filtered || !verdict) {
+    return { filtered: false, verdict: null, reason: null };
+  }
+  const reason = fullSource ? verdict : `${verdict} (${agree} sources)`;
+  return { filtered: true, verdict, reason };
+}

--- a/packages/core/src/screener/feedback.ts
+++ b/packages/core/src/screener/feedback.ts
@@ -1,0 +1,20 @@
+import { ScreenerStore } from '../db/repositories/screener.js';
+import { createLogger } from '../logging/logger.js';
+import { keyKind } from './key.js';
+import { myBackbones } from './backbones.js';
+
+const logger = createLogger('screener');
+
+/**
+ * Mark a release key dead. Use when the caller already knows the release is
+ * gone (e.g. the native usenet engine catching an `ArticleNotFoundError`).
+ * Fire-and-forget; no-op for a missing/invalid key.
+ */
+export function markReleaseDead(key: string | null | undefined): void {
+  // Usenet-only path: never let a torrent (btih) key in here.
+  if (!key || keyKind(key) !== 'usenet') return;
+  logger.debug(`Screener: auto-marking dead release ${key}`);
+  void ScreenerStore.markVerdict(key, 'dead', myBackbones()).catch((e) =>
+    logger.warn(`Screener auto-mark failed for ${key}: ${e}`)
+  );
+}

--- a/packages/core/src/screener/filter.ts
+++ b/packages/core/src/screener/filter.ts
@@ -1,0 +1,96 @@
+import { ScreenerStore } from '../db/repositories/screener.js';
+import { createLogger } from '../logging/logger.js';
+import { streamReleaseKey, type KeyableStream } from './stream-key.js';
+import type { ScreenerEvalOptions, ScreenerVerdict } from './types.js';
+
+const logger = createLogger('screener');
+
+const DEFAULT_QUORUM = 2;
+
+/** Per-user Screener knobs (from UserData). */
+export interface ScreenerUserOptions {
+  enabled?: boolean;
+  quorum?: number;
+  backboneScope?: boolean;
+}
+
+type FilterableStream = KeyableStream & { id: string };
+
+/**
+ * Drop streams whose release was flagged (dead/fake/mislabeled) by the Screener,
+ * evaluated against the user's quorum/backbone settings. Runs before dedup so a
+ * flagged candidate never becomes a failover attempt.
+ *
+ * Default-on: filters unless the user explicitly disabled it. Never leaves the
+ * user with nothing, if every stream is flagged, all are shown as a last resort
+ * (mirroring nzbdavex). Returns the input array unchanged when nothing is
+ * dropped, so callers can cheaply detect a no-op.
+ */
+export async function applyScreener<T extends FilterableStream>(
+  streams: T[],
+  opts: ScreenerUserOptions | undefined,
+  myBackbones: string[],
+  onRemoved?: (stream: T, verdict: ScreenerVerdict) => void
+): Promise<T[]> {
+  if (opts?.enabled === false || streams.length === 0) return streams;
+  try {
+    if (!(await ScreenerStore.hasEntries())) return streams;
+  } catch (err) {
+    // Fail open: a store hiccup must never reject the request.
+    logger.debug(`screener presence check failed, passing through: ${err}`);
+    return streams;
+  }
+
+  // Key by the stream object itself, not stream.id: ids can repeat across
+  // streams and an id-keyed map would judge one against another's verdict.
+  const keyByStream = new Map<T, string>();
+  for (const s of streams) {
+    const key = streamReleaseKey(s);
+    if (key) keyByStream.set(s, key);
+  }
+  if (keyByStream.size === 0) return streams;
+
+  const evalOpts: ScreenerEvalOptions = {
+    quorum: opts?.quorum ?? DEFAULT_QUORUM,
+    backboneScope: opts?.backboneScope ?? true,
+    myBackbones,
+  };
+
+  let verdicts;
+  try {
+    verdicts = await ScreenerStore.evaluateKeys(
+      [...new Set(keyByStream.values())],
+      evalOpts
+    );
+  } catch (err) {
+    logger.debug(`screener evaluate failed, passing streams through: ${err}`);
+    return streams;
+  }
+
+  const kept: T[] = [];
+  const removed: Array<{ stream: T; verdict: ScreenerVerdict }> = [];
+  for (const s of streams) {
+    const key = keyByStream.get(s);
+    const verdict = key ? verdicts.get(key) : undefined;
+    if (verdict?.filtered) {
+      removed.push({ stream: s, verdict });
+      continue;
+    }
+    kept.push(s);
+  }
+
+  if (removed.length === 0) return streams;
+  if (kept.length === 0) {
+    // Never leave the user with nothing, show all as a last resort, and don't
+    // record the skips since nothing was actually removed.
+    logger.warn(
+      `Screener flagged all ${streams.length} stream(s); showing anyway (last resort)`
+    );
+    return streams;
+  }
+  for (const r of removed) onRemoved?.(r.stream, r.verdict);
+  logger.info(
+    `Screener removed ${removed.length} flagged release(s); ${kept.length} remain`
+  );
+  return kept;
+}

--- a/packages/core/src/screener/fingerprint.test.ts
+++ b/packages/core/src/screener/fingerprint.test.ts
@@ -1,0 +1,93 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  computeFingerprint,
+  isValidFingerprint,
+  toUnixSeconds,
+} from './fingerprint.js';
+
+// Golden vectors are the faithful output of nzbdavex's WardenFingerprint.Compute
+// for the same inputs. If these change, aiostreams lists stop interchanging with
+// nzbdavex, treat any diff as a wire-compat break, not a test to "fix".
+const SIZE = 1073741824; // 1 GiB
+const POSTER = 'a@b.com';
+const DATE = 1719705600; // 2024-06-30 00:00:00 UTC
+
+describe('computeFingerprint (davex wd1 wire-compat)', () => {
+  it('matches the golden vector for size+poster+date', () => {
+    assert.equal(
+      computeFingerprint(SIZE, POSTER, DATE),
+      'wd1:fbaefac71441d3539764427a8111b8c7'
+    );
+  });
+
+  it('normalises poster case and surrounding whitespace', () => {
+    assert.equal(
+      computeFingerprint(SIZE, '  A@B.COM  ', DATE),
+      'wd1:fbaefac71441d3539764427a8111b8c7'
+    );
+  });
+
+  it('matches the golden vector with date only (no poster)', () => {
+    assert.equal(
+      computeFingerprint(SIZE, null, DATE),
+      'wd1:0503cb01e09543055e408e9060dfd1ea'
+    );
+    assert.equal(computeFingerprint(SIZE, '   ', DATE), 'wd1:0503cb01e09543055e408e9060dfd1ea');
+  });
+
+  it('matches the golden vector with poster only (no date)', () => {
+    assert.equal(
+      computeFingerprint(SIZE, POSTER, null),
+      'wd1:d18312f44c157e5c69f656a234986e23'
+    );
+  });
+
+  it('buckets the posting date to the day', () => {
+    const base = computeFingerprint(SIZE, POSTER, DATE);
+    assert.equal(computeFingerprint(SIZE, POSTER, DATE + 86399), base);
+    assert.notEqual(computeFingerprint(SIZE, POSTER, DATE + 86400), base);
+  });
+
+  it('returns null for non-identifying inputs', () => {
+    assert.equal(computeFingerprint(0, POSTER, DATE), null);
+    assert.equal(computeFingerprint(-1, POSTER, DATE), null);
+    assert.equal(computeFingerprint(SIZE, null, null), null);
+    assert.equal(computeFingerprint(SIZE, '  ', null), null);
+    assert.equal(computeFingerprint(Number.NaN, POSTER, DATE), null);
+  });
+
+  it('produces a syntactically valid fingerprint', () => {
+    assert.ok(isValidFingerprint(computeFingerprint(SIZE, POSTER, DATE)));
+    assert.ok(!isValidFingerprint('wd1:nothex'));
+    assert.ok(!isValidFingerprint('xx1:fbaefac71441d3539764427a8111b8c7'));
+    assert.ok(!isValidFingerprint(null));
+  });
+});
+
+describe('toUnixSeconds', () => {
+  it('passes through epoch seconds', () => {
+    assert.equal(toUnixSeconds(DATE), DATE);
+  });
+
+  it('downscales epoch milliseconds', () => {
+    assert.equal(toUnixSeconds(DATE * 1000), DATE);
+  });
+
+  it('parses an RFC-822 / ISO date string to the same bucket', () => {
+    const iso = toUnixSeconds('2024-06-30T00:00:00Z');
+    assert.equal(iso, DATE);
+    // A feed reporting a string and one reporting seconds agree on the fp.
+    assert.equal(
+      computeFingerprint(SIZE, POSTER, iso),
+      computeFingerprint(SIZE, POSTER, DATE)
+    );
+  });
+
+  it('returns null for junk', () => {
+    assert.equal(toUnixSeconds(''), null);
+    assert.equal(toUnixSeconds('not a date'), null);
+    assert.equal(toUnixSeconds(null), null);
+    assert.equal(toUnixSeconds(undefined), null);
+  });
+});

--- a/packages/core/src/screener/fingerprint.ts
+++ b/packages/core/src/screener/fingerprint.ts
@@ -1,0 +1,105 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Screener release fingerprint, a credential-free, provider/indexer-agnostic
+ * identity for a single Usenet release, derived only from its indexer-reported
+ * size, poster, and posting day.
+ *
+ * Wire-compatible with nzbdavex's `WardenFingerprint.Compute`
+ * (backend/Utils/WardenFingerprint.cs):
+ *
+ *   wd1: + lowercaseHex( SHA256(`{size}|{posterLower}|{dayBucket}`)[0..16] )
+ *
+ * The same dead release produces the same fingerprint on any server, indexer or
+ * provider, so dead-release lists are interchangeable between aiostreams and
+ * nzbdavex. The hash carries no credentials, titles or URLs, only a digest.
+ */
+
+const FP_PATTERN = /^wd1:[0-9a-f]{32}$/;
+const SECONDS_PER_DAY = 86400;
+
+/** True when `fp` is a syntactically valid `wd1:` fingerprint. */
+export function isValidFingerprint(
+  fp: string | null | undefined
+): fp is string {
+  return typeof fp === 'string' && FP_PATTERN.test(fp);
+}
+
+/**
+ * Compute a release fingerprint. Returns `null` when the inputs are too weak to
+ * identify a release (no size, or neither poster nor date), matching davex,
+ * which never stores or filters on a weak fingerprint.
+ *
+ * `size` must be the indexer-reported byte size (the exact release size), NOT
+ * the NZB's summed encoded segment size, that is what davex hashes, and using
+ * anything else would break cross-tool matching.
+ *
+ * @param size indexer-reported release size in bytes
+ * @param poster the release's poster / `from` header, if the indexer provided one
+ * @param usenetDateUnixSeconds posting date in unix *seconds*, if known
+ */
+export function computeFingerprint(
+  size: number,
+  poster: string | null | undefined,
+  usenetDateUnixSeconds: number | null | undefined
+): string | null {
+  // Byte sizes are exact integers; a fractional or above-2^53 (already-rounded)
+  // value would mint a wd1 for a size no other implementation derives.
+  if (!Number.isSafeInteger(size) || size <= 0) return null;
+
+  const hasPoster = typeof poster === 'string' && poster.trim() !== '';
+  const hasDate =
+    typeof usenetDateUnixSeconds === 'number' &&
+    Number.isFinite(usenetDateUnixSeconds);
+  if (!hasPoster && !hasDate) return null;
+
+  const posterNorm = hasPoster ? poster!.trim().toLowerCase() : '';
+  const dayBucket = hasDate
+    ? Math.floor(usenetDateUnixSeconds! / SECONDS_PER_DAY)
+    : 0;
+  const canonical = `${size}|${posterNorm}|${dayBucket}`;
+
+  const hash = createHash('sha256').update(canonical, 'utf8').digest();
+  return 'wd1:' + hash.subarray(0, 16).toString('hex');
+}
+
+/**
+ * Coerce an indexer-supplied date (epoch seconds, epoch millis, a `Date`, or a
+ * parseable date string such as RFC-822 `pubDate` / newznab `usenetdate`) to
+ * unix *seconds*, or `null` if it can't be parsed. Values that already look
+ * like epoch seconds are passed through so a feed reporting seconds and one
+ * reporting an equivalent ISO string land on the same day bucket.
+ */
+export function toUnixSeconds(
+  value: string | number | Date | null | undefined
+): number | null {
+  if (value == null) return null;
+
+  if (value instanceof Date) {
+    const ms = value.getTime();
+    return Number.isFinite(ms) ? Math.floor(ms / 1000) : null;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return null;
+    // Heuristic: >1e11 is almost certainly milliseconds (year ~5138 in seconds).
+    return Math.floor(value > 1e11 ? value / 1000 : value);
+  }
+
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+
+  if (/^\d+$/.test(trimmed)) {
+    const n = Number(trimmed);
+    return Number.isFinite(n) ? Math.floor(n > 1e11 ? n / 1000 : n) : null;
+  }
+
+  // A date-time without a timezone is parsed in the host's local zone, which
+  // would bucket the wd1 differently across machines. Reject those so the key
+  // stays portable; date-only and tz-qualified strings parse deterministically.
+  const hasTime = /\d{1,2}:\d{2}/.test(trimmed);
+  const hasZone = /(?:Z|[+-]\d{2}:?\d{2}|\b(?:GMT|UTC|UT)\b)/i.test(trimmed);
+  if (hasTime && !hasZone) return null;
+  const ms = Date.parse(trimmed);
+  return Number.isNaN(ms) ? null : Math.floor(ms / 1000);
+}

--- a/packages/core/src/screener/index.ts
+++ b/packages/core/src/screener/index.ts
@@ -1,0 +1,34 @@
+export {
+  type Verdict,
+  VERDICTS,
+  isVerdict,
+  moreSevere,
+  type Trust,
+  TRUSTS,
+  normaliseTrust,
+  type ReleaseKind,
+  type SourceKind,
+  LOCAL_SOURCE_ID,
+  type ScreenerEntry,
+  type ScreenerRecord,
+  type ScreenerSource,
+  type ScreenerEvalOptions,
+  type ScreenerVerdict,
+} from './types.js';
+export {
+  computeFingerprint,
+  isValidFingerprint,
+  toUnixSeconds,
+} from './fingerprint.js';
+export { torrentKey, usenetKey, keyKind, isValidKey, parseKey } from './key.js';
+export {
+  toNdjson,
+  toDavexNdjson,
+  parseNdjson,
+  dedupeRecords,
+  type ParsedNdjson,
+} from './io.js';
+export { streamReleaseKey, type KeyableStream } from './stream-key.js';
+export { applyScreener, type ScreenerUserOptions } from './filter.js';
+export { markReleaseDead } from './feedback.js';
+export { ScreenerRemoteSourceService } from './remote.js';

--- a/packages/core/src/screener/io.test.ts
+++ b/packages/core/src/screener/io.test.ts
@@ -1,0 +1,131 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { toNdjson, toDavexNdjson, parseNdjson, dedupeRecords } from './io.js';
+import type { ScreenerRecord } from './types.js';
+
+const WD1 = 'wd1:fbaefac71441d3539764427a8111b8c7';
+const BTIH = 'btih:' + 'a'.repeat(40);
+
+const RECORDS: ScreenerRecord[] = [
+  { k: WD1, v: 'dead', n: 3, at: 1719705600, bk: ['news.example.com'] },
+  { k: BTIH, v: 'fake', n: 1, at: 1719705600 },
+];
+
+describe('native NDJSON round-trip', () => {
+  it('writes a header then one record per line', () => {
+    const text = toNdjson(RECORDS, 1719799999);
+    const lines = text.trim().split('\n');
+    assert.deepEqual(JSON.parse(lines[0]), { screener: 1, updated: 1719799999 });
+    assert.equal(lines.length, 3);
+  });
+
+  it('parses back to the same records (skipping the header)', () => {
+    const { records, invalid } = parseNdjson(toNdjson(RECORDS, 1719799999));
+    assert.equal(invalid, 0);
+    assert.equal(records.length, 2);
+    assert.deepEqual(records[0], RECORDS[0]);
+    assert.equal(records[1].k, BTIH);
+    assert.equal(records[1].v, 'fake');
+  });
+});
+
+describe('davex bridge', () => {
+  it('exports only the dead usenet subset in davex format', () => {
+    const text = toDavexNdjson(RECORDS, 1719799999);
+    const lines = text.trim().split('\n');
+    assert.deepEqual(JSON.parse(lines[0]), { warden: 1, updated: 1719799999 });
+    // BTIH (torrent) and any non-dead are dropped; only the WD1 dead remains.
+    assert.equal(lines.length, 2);
+    assert.deepEqual(JSON.parse(lines[1]), {
+      fp: WD1,
+      bk: ['news.example.com'],
+      deadAt: 1719705600,
+      n: 3,
+    });
+  });
+
+  it('imports a davex file as dead usenet verdicts', () => {
+    const davex =
+      JSON.stringify({ warden: 1, updated: 1719799999 }) +
+      '\n' +
+      JSON.stringify({ fp: WD1, bk: ['news.example.com'], deadAt: 1719705600, n: 5 }) +
+      '\n';
+    const { records, invalid } = parseNdjson(davex);
+    assert.equal(invalid, 0);
+    assert.equal(records.length, 1);
+    assert.deepEqual(records[0], {
+      k: WD1,
+      v: 'dead',
+      n: 5,
+      at: 1719705600,
+      bk: ['news.example.com'],
+    });
+  });
+
+  it('round-trips aiostreams -> davex -> aiostreams losslessly for dead usenet', () => {
+    const davex = toDavexNdjson(RECORDS, 1719799999);
+    const { records } = parseNdjson(davex);
+    assert.equal(records.length, 1);
+    assert.deepEqual(records[0], RECORDS[0]);
+  });
+});
+
+describe('parse robustness', () => {
+  it('counts malformed lines as invalid but keeps good ones', () => {
+    const text = [
+      JSON.stringify({ screener: 1, updated: 1 }),
+      JSON.stringify({ k: WD1, v: 'dead', n: 1, at: 1719705600 }),
+      'not json',
+      JSON.stringify({ k: 'bogus-key', v: 'dead', n: 1, at: 1 }),
+      JSON.stringify({ k: BTIH, v: 'not-a-verdict', n: 1, at: 1 }),
+      '# a comment',
+      '',
+    ].join('\n');
+    const { records, invalid } = parseNdjson(text);
+    assert.equal(records.length, 1);
+    assert.equal(invalid, 3); // bad json, bad key, bad verdict
+  });
+
+  it('defaults a non-positive count to 1', () => {
+    const { records } = parseNdjson(
+      JSON.stringify({ k: BTIH, v: 'dead', n: 0, at: 5 }) + '\n'
+    );
+    assert.equal(records[0].n, 1);
+  });
+
+  it('trims backbones and drops blank ones on import', () => {
+    const { records } = parseNdjson(
+      JSON.stringify({
+        k: WD1,
+        v: 'dead',
+        n: 1,
+        at: 5,
+        bk: ['  news.a.com ', '', '   ', 'news.b.com'],
+      }) + '\n'
+    );
+    assert.deepEqual(records[0].bk, ['news.a.com', 'news.b.com']);
+  });
+});
+
+describe('dedupeRecords (export merge)', () => {
+  it('keeps the most severe verdict, sums counts, takes the newest timestamp', () => {
+    const out = dedupeRecords([
+      { k: WD1, v: 'dead', n: 2, at: 10, bk: ['a.com'] },
+      { k: WD1, v: 'mislabeled', n: 3, at: 20, bk: ['b.com'] },
+    ]);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].v, 'dead');
+    assert.equal(out[0].n, 5);
+    assert.equal(out[0].at, 20);
+    assert.deepEqual(out[0].bk, ['a.com', 'b.com']);
+  });
+
+  it('stays global when either side is unscoped', () => {
+    const out = dedupeRecords([
+      { k: WD1, v: 'dead', n: 1, at: 10, bk: ['a.com'] },
+      { k: WD1, v: 'dead', n: 1, at: 10 },
+    ]);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].bk, undefined);
+  });
+});

--- a/packages/core/src/screener/io.ts
+++ b/packages/core/src/screener/io.ts
@@ -1,0 +1,184 @@
+import { isValidKey, keyKind } from './key.js';
+import {
+  isVerdict,
+  moreSevere,
+  N_CAP,
+  type ScreenerRecord,
+  type Verdict,
+} from './types.js';
+
+/**
+ * The portable interchange format. NDJSON: a header line then one record per
+ * line. Two dialects are read transparently on import:
+ *
+ *   native (aiostreams)  header {"screener":1,"updated":<unix>}
+ *                        record {"k":"btih:...|wd1:...","v":"dead","n":1,"at":<unix>,"bk":[...]}
+ *
+ *   davex  (nzbdavex)    header {"warden":1,"updated":<unix>}
+ *                        record {"fp":"wd1:...","bk":[...],"deadAt":<unix>,"n":1}
+ *
+ * davex only carries dead usenet fingerprints, so its records import as
+ * `verdict: 'dead'`. Exporting the usenet subset back to davex (see
+ * `toDavexNdjson`) is lossless, which is what keeps the two ecosystems sharing
+ * one pool.
+ */
+
+export interface ParsedNdjson {
+  records: ScreenerRecord[];
+  /** Lines that were non-empty but not a valid record (excludes the header). */
+  invalid: number;
+}
+
+/** Serialize records as native NDJSON with a header stamped `updatedAt`. */
+export function toNdjson(
+  records: readonly ScreenerRecord[],
+  updatedAt: number
+): string {
+  const lines: string[] = [
+    JSON.stringify({ screener: 1, updated: Math.trunc(updatedAt) }),
+  ];
+  for (const r of records) {
+    const line: ScreenerRecord = { k: r.k, v: r.v, n: r.n, at: r.at };
+    if (r.bk && r.bk.length > 0) line.bk = r.bk;
+    lines.push(JSON.stringify(line));
+  }
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Serialize the usenet (`wd1:`) subset as davex-format NDJSON so the list can be
+ * consumed by an nzbdavex Warden. Non-usenet keys are dropped (davex can't use
+ * them). Only `dead` is meaningful to davex; other verdicts are dropped.
+ */
+export function toDavexNdjson(
+  records: readonly ScreenerRecord[],
+  updatedAt: number
+): string {
+  const lines: string[] = [
+    JSON.stringify({ warden: 1, updated: Math.trunc(updatedAt) }),
+  ];
+  for (const r of records) {
+    if (r.v !== 'dead' || keyKind(r.k) !== 'usenet') continue;
+    lines.push(
+      JSON.stringify({ fp: r.k, bk: r.bk ?? [], deadAt: r.at, n: r.n })
+    );
+  }
+  return lines.join('\n') + '\n';
+}
+
+/** Build a record from an already-parsed line, or null if it isn't a usable one. */
+function parseLine(obj: any): ScreenerRecord | null {
+  if (obj === null || typeof obj !== 'object') return null;
+
+  // davex record
+  if (typeof obj.fp === 'string') {
+    if (!isValidKey(obj.fp) || keyKind(obj.fp) !== 'usenet') return null;
+    const rec: ScreenerRecord = {
+      k: obj.fp,
+      v: 'dead',
+      n: toCount(obj.n),
+      at: toUnix(obj.deadAt),
+    };
+    const bk = toBk(obj.bk);
+    if (bk) rec.bk = bk;
+    return rec;
+  }
+
+  // native record
+  if (typeof obj.k === 'string') {
+    if (!isValidKey(obj.k) || !isVerdict(obj.v)) return null;
+    const rec: ScreenerRecord = {
+      k: obj.k,
+      v: obj.v as Verdict,
+      n: toCount(obj.n),
+      at: toUnix(obj.at),
+    };
+    const bk = toBk(obj.bk);
+    if (bk) rec.bk = bk;
+    return rec;
+  }
+
+  // header ({screener|warden, updated}) or unknown shape
+  return null;
+}
+
+/** Parse a whole NDJSON document (native or davex), skipping header/blank lines. */
+export function parseNdjson(text: string): ParsedNdjson {
+  const records: ScreenerRecord[] = [];
+  let invalid = 0;
+  for (const raw of text.split('\n')) {
+    const trimmed = raw.trim();
+    if (trimmed === '' || trimmed.startsWith('#')) continue;
+    let obj: unknown;
+    try {
+      obj = JSON.parse(trimmed);
+    } catch {
+      invalid++;
+      continue;
+    }
+    // A header line is valid input, not an invalid record, don't count it.
+    if (isHeader(obj)) continue;
+    const rec = parseLine(obj);
+    if (rec) records.push(rec);
+    else invalid++;
+  }
+  return { records, invalid };
+}
+
+function isHeader(obj: any): boolean {
+  if (!obj || typeof obj !== 'object') return false;
+  if (obj.k !== undefined || obj.fp !== undefined) return false;
+  // The version field must be a number, so a malformed first line like
+  // {"screener":"oops"} is treated as an invalid record, not a header.
+  return typeof obj.screener === 'number' || typeof obj.warden === 'number';
+}
+
+function toCount(n: unknown): number {
+  const v = Number(n);
+  // A positive but fractional count still means "seen once", never truncate it
+  // to 0 and silently drop the record's weight.
+  return Number.isFinite(v) && v > 0 ? Math.max(1, Math.trunc(v)) : 1;
+}
+
+function toUnix(at: unknown): number {
+  const v = Number(at);
+  return Number.isFinite(v) && v > 0 ? Math.trunc(v) : 0;
+}
+
+function toBk(bk: unknown): string[] | undefined {
+  if (!Array.isArray(bk)) return undefined;
+  const out = bk
+    .filter((b): b is string => typeof b === 'string' && b.trim() !== '')
+    .map((b) => b.trim());
+  return out.length > 0 ? out : undefined;
+}
+
+/**
+ * Merge duplicate records (same key) across sources for export. Keeps the most
+ * severe verdict, sums counts (capped), takes the newest timestamp, and unions
+ * backbones, an empty/omitted `bk` is global and stays global rather than being
+ * narrowed by a scoped sibling.
+ */
+export function dedupeRecords(
+  records: readonly ScreenerRecord[]
+): ScreenerRecord[] {
+  const merged = new Map<string, ScreenerRecord>();
+  for (const rec of records) {
+    const existing = merged.get(rec.k);
+    if (!existing) {
+      merged.set(rec.k, { ...rec });
+      continue;
+    }
+    existing.v = moreSevere(existing.v, rec.v);
+    existing.n = Math.min(existing.n + rec.n, N_CAP);
+    existing.at = Math.max(existing.at, rec.at);
+    const existingBk = existing.bk ?? [];
+    const recBk = rec.bk ?? [];
+    if (existingBk.length === 0 || recBk.length === 0) {
+      delete existing.bk;
+    } else {
+      existing.bk = [...new Set([...existingBk, ...recBk])];
+    }
+  }
+  return [...merged.values()];
+}

--- a/packages/core/src/screener/key.test.ts
+++ b/packages/core/src/screener/key.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  torrentKey,
+  usenetKey,
+  keyKind,
+  isValidKey,
+  parseKey,
+} from './key.js';
+
+const HASH40 = 'abcdef0123456789abcdef0123456789abcdef01';
+const HASH64 = 'a'.repeat(64);
+
+describe('torrentKey', () => {
+  it('lowercases and prefixes a v1 infohash', () => {
+    assert.equal(torrentKey(HASH40.toUpperCase()), `btih:${HASH40}`);
+    assert.equal(torrentKey(`  ${HASH40}  `), `btih:${HASH40}`);
+  });
+
+  it('accepts a v2 (64-hex) infohash', () => {
+    assert.equal(torrentKey(HASH64), `btih:${HASH64}`);
+  });
+
+  it('rejects non-hex / wrong-length / empty', () => {
+    assert.equal(torrentKey('not-a-hash'), null);
+    assert.equal(torrentKey('abc'), null);
+    assert.equal(torrentKey(''), null);
+    assert.equal(torrentKey(null), null);
+  });
+});
+
+describe('usenetKey', () => {
+  it('delegates to the wd1 fingerprint', () => {
+    assert.equal(
+      usenetKey(1073741824, 'a@b.com', 1719705600),
+      'wd1:fbaefac71441d3539764427a8111b8c7'
+    );
+  });
+
+  it('returns null for non-identifying input', () => {
+    assert.equal(usenetKey(0, 'a@b.com', 1719705600), null);
+  });
+});
+
+describe('keyKind / isValidKey / parseKey', () => {
+  it('classifies torrent and usenet keys by prefix', () => {
+    assert.equal(keyKind(`btih:${HASH40}`), 'torrent');
+    assert.equal(keyKind('wd1:fbaefac71441d3539764427a8111b8c7'), 'usenet');
+  });
+
+  it('rejects malformed keys', () => {
+    assert.equal(keyKind('btih:xyz'), null);
+    assert.equal(keyKind('wd1:nothex'), null);
+    assert.equal(keyKind('plain'), null);
+    assert.equal(keyKind(null), null);
+    assert.ok(!isValidKey('btih:short'));
+  });
+
+  it('parseKey strips the btih prefix but keeps the wd1 key whole', () => {
+    assert.deepEqual(parseKey(`btih:${HASH40}`), {
+      kind: 'torrent',
+      id: HASH40,
+    });
+    assert.deepEqual(parseKey('wd1:fbaefac71441d3539764427a8111b8c7'), {
+      kind: 'usenet',
+      id: 'wd1:fbaefac71441d3539764427a8111b8c7',
+    });
+    assert.equal(parseKey('garbage'), null);
+  });
+});

--- a/packages/core/src/screener/key.ts
+++ b/packages/core/src/screener/key.ts
@@ -1,0 +1,63 @@
+import { computeFingerprint, isValidFingerprint } from './fingerprint.js';
+import type { ReleaseKind } from './types.js';
+
+/**
+ * A Screener release key is a self-describing, credential-free identity for a
+ * release, stable across indexers/providers/servers so verdicts can be shared:
+ *
+ *   torrent  ->  btih:<infohash>      (lowercase hex; bittorrent v1 or v2)
+ *   usenet   ->  wd1:<fingerprint>    (davex-compatible; size|poster|day)
+ *
+ * `releaseKind` is re-exported from types for callers that key off the prefix.
+ */
+
+export type { ReleaseKind } from './types.js';
+
+const BTIH_V1 = /^[0-9a-f]{40}$/;
+const BTIH_V2 = /^[0-9a-f]{64}$/;
+
+/** Build a torrent key from an infohash, or null if it isn't recognisable. */
+export function torrentKey(infoHash: string | null | undefined): string | null {
+  if (typeof infoHash !== 'string') return null;
+  const h = infoHash.trim().toLowerCase();
+  if (BTIH_V1.test(h) || BTIH_V2.test(h)) return `btih:${h}`;
+  return null;
+}
+
+/**
+ * Build a usenet key from indexer-reported size/poster/date. Returns the
+ * `wd1:` fingerprint (already prefix-tagged) or null for non-identifying input.
+ */
+export function usenetKey(
+  size: number,
+  poster: string | null | undefined,
+  usenetDateUnixSeconds: number | null | undefined
+): string | null {
+  return computeFingerprint(size, poster, usenetDateUnixSeconds);
+}
+
+/** The kind a key denotes, from its prefix, or null if unrecognised/invalid. */
+export function keyKind(key: string | null | undefined): ReleaseKind | null {
+  if (typeof key !== 'string') return null;
+  if (key.startsWith('btih:')) {
+    const h = key.slice(5);
+    return BTIH_V1.test(h) || BTIH_V2.test(h) ? 'torrent' : null;
+  }
+  if (key.startsWith('wd1:')) return isValidFingerprint(key) ? 'usenet' : null;
+  return null;
+}
+
+/** True when `key` is a syntactically valid release key. */
+export function isValidKey(key: string | null | undefined): key is string {
+  return keyKind(key) !== null;
+}
+
+/** Split a key into its kind and raw id (`btih:` keys lose the prefix). */
+export function parseKey(
+  key: string | null | undefined
+): { kind: ReleaseKind; id: string } | null {
+  const kind = keyKind(key);
+  if (!kind) return null;
+  const k = key as string;
+  return { kind, id: kind === 'torrent' ? k.slice(5) : k };
+}

--- a/packages/core/src/screener/remote.ts
+++ b/packages/core/src/screener/remote.ts
@@ -1,0 +1,123 @@
+import { gunzip } from 'node:zlib';
+import { promisify } from 'node:util';
+import { ScreenerStore } from '../db/repositories/screener.js';
+import { parseNdjson } from './io.js';
+import { createLogger, makeRequest } from '../utils/index.js';
+import { redactUrlParams } from '../logging/redact.js';
+import type { ScreenerSource } from './types.js';
+
+const logger = createLogger('screener-remote');
+const gunzipAsync = promisify(gunzip);
+
+const MAX_DOWNLOAD_BYTES = 64 * 1024 * 1024;
+const FETCH_TIMEOUT_MS = 90_000;
+
+/**
+ * Read a response body into a buffer, aborting as soon as it exceeds `max`. A
+ * server that omits Content-Length can't flood memory because we stop on the
+ * first chunk that crosses the limit rather than buffering the whole body.
+ */
+async function readBodyCapped(
+  body: ReadableStream<Uint8Array> | null,
+  max: number
+): Promise<Buffer> {
+  if (!body) return Buffer.alloc(0);
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of body as AsyncIterable<Uint8Array>) {
+    total += chunk.length;
+    if (total > max) throw new Error('Download exceeds the size limit.');
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+/**
+ * Refreshes remote Screener list subscriptions: fetch the URL, gunzip if the
+ * body is a `.gz`, parse it (native or davex NDJSON), and replace that source's
+ * entries. Conditional on ETag so unchanged lists are cheap. Operator-configured
+ * URLs only; nothing here trusts user input.
+ */
+export class ScreenerRemoteSourceService {
+  /** Refresh every remote source whose refresh interval has elapsed. */
+  static async refreshDue(): Promise<void> {
+    const now = nowSec();
+    // Let a listing failure propagate so the scheduled task reports it instead
+    // of silently "succeeding". Per-source failures stay contained in
+    // refreshOne, so one bad source can't abort the sweep.
+    const sources = await ScreenerStore.getSources();
+    for (const source of sources) {
+      if (!source.enabled || source.kind !== 'remote' || !source.url) continue;
+      if (now - source.lastChecked < source.refreshHours * 3600) continue;
+      await this.refreshOne(source);
+    }
+  }
+
+  /** Refresh a single remote source now. Returns a short status string. */
+  static async refreshOne(source: ScreenerSource): Promise<string> {
+    const now = nowSec();
+    if (!source.url) {
+      await ScreenerStore.touchChecked(source.id, now, 'error: no url');
+      return 'error: no url';
+    }
+    try {
+      const etag = await ScreenerStore.getSourceEtag(source.id);
+      const res = await makeRequest(source.url, {
+        method: 'GET',
+        timeout: FETCH_TIMEOUT_MS,
+        headers: etag ? { 'If-None-Match': etag } : undefined,
+      });
+
+      if (res.status === 304) {
+        await ScreenerStore.touchChecked(source.id, now, `ok (${source.count})`);
+        return 'not-modified';
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+      // Reject early on a declared oversize body, and cap the decompressed
+      // payload so a small `.gz` can't expand past the limit and exhaust memory.
+      const declared = Number(res.headers.get('content-length'));
+      if (Number.isFinite(declared) && declared > MAX_DOWNLOAD_BYTES) {
+        throw new Error('Download exceeds the size limit.');
+      }
+      const buf = await readBodyCapped(res.body, MAX_DOWNLOAD_BYTES);
+      const text = looksGzip(buf)
+        ? (
+            await gunzipAsync(buf, { maxOutputLength: MAX_DOWNLOAD_BYTES })
+          ).toString('utf8')
+        : buf.toString('utf8');
+
+      const { records, invalid } = parseNdjson(text);
+      // Fail closed: don't let an empty or mostly-unparseable response (e.g. an
+      // HTML error page served with 200) replace a good source. A few unknown
+      // lines (a newer format the reader doesn't recognise yet) are tolerated.
+      if (records.length === 0 || invalid > records.length) {
+        throw new Error('Remote list is empty or malformed.');
+      }
+      const count = await ScreenerStore.bulkUpsert(source.id, records, {
+        replace: true,
+      });
+      const newEtag = res.headers.get('etag');
+      await ScreenerStore.setSourceStatus(source.id, newEtag, now, now, `ok (${count})`);
+      logger.info(
+        `refreshed remote list "${source.name}" (${count} entries${invalid ? `, ${invalid} skipped` : ''})`
+      );
+      return `ok (${count})`;
+    } catch (err) {
+      const msg =
+        'error: ' +
+        redactUrlParams(err instanceof Error ? err.message : String(err));
+      await ScreenerStore.touchChecked(source.id, now, msg);
+      logger.debug(`refresh failed for "${source.name}": ${msg}`);
+      return msg;
+    }
+  }
+}
+
+function nowSec(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+function looksGzip(buf: Buffer): boolean {
+  return buf.length >= 2 && buf[0] === 0x1f && buf[1] === 0x8b;
+}

--- a/packages/core/src/screener/stream-key.test.ts
+++ b/packages/core/src/screener/stream-key.test.ts
@@ -1,0 +1,40 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { streamReleaseKey } from './stream-key.js';
+
+const HASH = 'a'.repeat(40);
+const WD1 = 'wd1:fbaefac71441d3539764427a8111b8c7';
+
+describe('streamReleaseKey', () => {
+  it('derives a btih key from a torrent infohash', () => {
+    assert.equal(
+      streamReleaseKey({ type: 'debrid', torrent: { infoHash: HASH.toUpperCase() } }),
+      `btih:${HASH}`
+    );
+  });
+
+  it('uses a precomputed usenet key', () => {
+    assert.equal(
+      streamReleaseKey({ type: 'usenet', screenerKey: WD1 }),
+      WD1
+    );
+  });
+
+  it('prefers the infohash when both are present', () => {
+    assert.equal(
+      streamReleaseKey({ torrent: { infoHash: HASH }, screenerKey: WD1 }),
+      `btih:${HASH}`
+    );
+  });
+
+  it('returns null when nothing identifies the release', () => {
+    assert.equal(streamReleaseKey({ type: 'usenet' }), null);
+    assert.equal(streamReleaseKey({ type: 'http', torrent: null }), null);
+    assert.equal(streamReleaseKey({ screenerKey: 'not-a-key' }), null);
+    // A usenet stream must not adopt a torrent (btih) key via screenerKey.
+    assert.equal(
+      streamReleaseKey({ type: 'usenet', screenerKey: `btih:${HASH}` }),
+      null
+    );
+  });
+});

--- a/packages/core/src/screener/stream-key.ts
+++ b/packages/core/src/screener/stream-key.ts
@@ -1,0 +1,25 @@
+import { keyKind, torrentKey } from './key.js';
+
+/** The minimal shape of a stream needed to derive its Screener release key. */
+export interface KeyableStream {
+  type?: string;
+  torrent?: { infoHash?: string | null } | null;
+  /** Precomputed usenet key (`wd1:...`), set by the producing builtin. */
+  screenerKey?: string;
+}
+
+/**
+ * The release key for a stream, or null if it can't be identified. Torrents and
+ * debrid-over-torrent resolve from their infohash; usenet uses the key the
+ * builtin precomputed from size/poster/date (external usenet addons that don't
+ * provide one are simply not screened, they do their own filtering).
+ */
+export function streamReleaseKey(stream: KeyableStream): string | null {
+  const fromInfoHash = torrentKey(stream.torrent?.infoHash);
+  if (fromInfoHash) return fromInfoHash;
+  // screenerKey is usenet-only (wd1); a torrent key here would already have come
+  // from the infohash above.
+  const sk = stream.screenerKey;
+  if (sk && keyKind(sk) === 'usenet') return sk;
+  return null;
+}

--- a/packages/core/src/screener/types.ts
+++ b/packages/core/src/screener/types.ts
@@ -1,0 +1,116 @@
+/**
+ * Shared Screener shapes. Screener is aiostreams' community-shareable filter of bad
+ * releases, keyed by a credential-free release identity (see `key.ts`). The
+ * usenet subset is wire-compatible with nzbdavex (see `io.ts`).
+ */
+
+/** The class of source a release came from, derived from its key prefix. */
+export type ReleaseKind = 'torrent' | 'usenet';
+
+/** What a source says is wrong with a release. */
+export type Verdict = 'dead' | 'fake' | 'mislabeled';
+
+export const VERDICTS: readonly Verdict[] = ['dead', 'fake', 'mislabeled'];
+
+/**
+ * Severity for merge/display when sources disagree (higher wins). All verdicts
+ * filter equally; severity only decides which label a release surfaces under.
+ */
+const VERDICT_SEVERITY: Record<Verdict, number> = {
+  fake: 3,
+  dead: 2,
+  mislabeled: 1,
+};
+
+export function isVerdict(v: string): v is Verdict {
+  return (VERDICTS as readonly string[]).includes(v);
+}
+
+/** Pick the more severe of two verdicts. */
+export function moreSevere(a: Verdict, b: Verdict): Verdict {
+  return VERDICT_SEVERITY[a] >= VERDICT_SEVERITY[b] ? a : b;
+}
+
+/**
+ * How much a source is trusted, mirroring nzbdavex:
+ *  - full        filters on its own
+ *  - corroborate filters only when >= quorum sources agree
+ *  - observe     never filters (kept for visibility only)
+ */
+export type Trust = 'full' | 'corroborate' | 'observe';
+
+export const TRUSTS: readonly Trust[] = ['full', 'corroborate', 'observe'];
+
+export function normaliseTrust(t: string | null | undefined): Trust {
+  const v = t?.trim().toLowerCase();
+  return v === 'full' || v === 'observe' ? v : 'corroborate';
+}
+
+/** The fixed id of the always-present, auto-filling local source. */
+export const LOCAL_SOURCE_ID = 'local';
+
+/** Cap on a verdict's observation count, to bound storage and merges. */
+export const N_CAP = 1_000_000_000;
+
+export type SourceKind = 'local' | 'remote' | 'imported';
+
+/** A single stored verdict for one release, from one source. */
+export interface ScreenerEntry {
+  /** Release key: `btih:<hash>` or `wd1:<fingerprint>`. */
+  key: string;
+  verdict: Verdict;
+  /** Number of times this verdict has been observed. */
+  n: number;
+  /** Last-seen, unix seconds. */
+  lastAt: number;
+  /** Usenet backbones / torrent trackers that observed it, for scoping. */
+  backbones: string[];
+}
+
+/** One line of the native NDJSON interchange format. Compact keys keep it small. */
+export interface ScreenerRecord {
+  /** key */
+  k: string;
+  /** verdict */
+  v: Verdict;
+  /** count */
+  n: number;
+  /** last-seen unix seconds */
+  at: number;
+  /** backbones / trackers */
+  bk?: string[];
+}
+
+/** A configured list a user/operator pulls verdicts from. */
+export interface ScreenerSource {
+  id: string;
+  kind: SourceKind;
+  name: string;
+  url: string | null;
+  enabled: boolean;
+  trust: Trust;
+  refreshHours: number;
+  lastChecked: number;
+  lastUpdated: number;
+  status: string | null;
+  /** Number of entries contributed by this source. */
+  count: number;
+}
+
+/** Per-request knobs that decide whether a key is filtered. From UserData. */
+export interface ScreenerEvalOptions {
+  /** Sources must agree this many times before a `corroborate` verdict filters. */
+  quorum: number;
+  /** Only honour remote/imported verdicts whose backbone matches one of mine. */
+  backboneScope: boolean;
+  /** My usenet backbones (root domains) / trackers, for backbone scoping. */
+  myBackbones: string[];
+}
+
+/** The outcome of evaluating one release key against all enabled sources. */
+export interface ScreenerVerdict {
+  filtered: boolean;
+  verdict: Verdict | null;
+  /** Short human reason, e.g. "dead (3 sources)". */
+  reason: string | null;
+}

--- a/packages/core/src/streams/filterer.ts
+++ b/packages/core/src/streams/filterer.ts
@@ -24,6 +24,8 @@ import { formatBitrate, formatBytes } from '../formatters/utils.js';
 import { iso6391ToLanguage } from '../utils/languages.js';
 import { ReleaseDate } from '../metadata/tmdb.js';
 import { StreamContext, ExtendedMetadata } from './context.js';
+import { applyScreener } from '../screener/filter.js';
+import { myBackbones } from '../screener/backbones.js';
 
 const logger = createLogger('filterer');
 
@@ -73,6 +75,7 @@ export interface FilterStatistics {
     requiredFilterCondition: Reason;
     size: Reason;
     bitrate: Reason;
+    screener: Reason;
   };
   included: {
     passthrough: Reason;
@@ -178,6 +181,7 @@ class StreamFilterer {
         requiredFilterCondition: { total: 0, details: {} },
         size: { total: 0, details: {} },
         bitrate: { total: 0, details: {} },
+        screener: { total: 0, details: {} },
       },
       included: {
         passthrough: { total: 0, details: {} },
@@ -239,6 +243,27 @@ class StreamFilterer {
 
   public getFilterStatistics() {
     return this.filterStatistics;
+  }
+
+  /**
+   * Remove releases the Screener has flagged (dead/fake/mislabeled), recording
+   * each as a `screener` removal so it surfaces in the filter stats / dashboard
+   * ("skipped due to Screener"). Run once over the full candidate set before
+   * dedup, so a flagged release never becomes a failover attempt.
+   */
+  public async screenFlagged(
+    streams: ParsedStream[]
+  ): Promise<ParsedStream[]> {
+    return applyScreener(
+      streams,
+      this.userData.screener,
+      myBackbones(),
+      (_stream, verdict) =>
+        this.incrementRemovalReason(
+          'screener',
+          verdict.reason ?? verdict.verdict ?? 'flagged'
+        )
+    );
   }
 
   public getFilterTimings(): FilterTimings {

--- a/packages/core/src/usenet/integration/stream-session.ts
+++ b/packages/core/src/usenet/integration/stream-session.ts
@@ -18,6 +18,7 @@ import {
 import { UsenetLibraryRepository } from '../../db/index.js';
 import { type UsenetStreamToken, decodeUsenetStreamToken } from './tokens.js';
 import { friendlyUsenetError } from './errors.js';
+import { markReleaseDead } from '../../screener/feedback.js';
 import { usenetEngineRegistry, getUsenetEngineConfig } from './engine.js';
 import { fetchNzb, parseNzbCached } from './library.js';
 
@@ -271,6 +272,13 @@ async function getStreamSession(
           decoded.filename,
           friendly.code
         ).catch(() => {});
+        // Articles missing on every provider == gone from usenet: self-fill the
+        // Screener. Gate on allProviders so a single-provider 430 (still alive
+        // elsewhere) doesn't poison the shared list. NotStreamableError is
+        // encrypted/etc — the release exists, so it's excluded already.
+        if (err instanceof ArticleNotFoundError && err.allProviders) {
+          markReleaseDead(decoded.screenerKey);
+        }
       }
       throw err;
     }

--- a/packages/core/src/usenet/integration/tokens.ts
+++ b/packages/core/src/usenet/integration/tokens.ts
@@ -16,6 +16,8 @@ export interface UsenetStreamToken {
   innerPath?: string;
   /** Best-effort display filename. */
   filename: string;
+  /** Davex-compatible Screener key (`wd1:...`), so a dead post can self-mark. */
+  screenerKey?: string;
 }
 
 /**

--- a/packages/core/src/utils/fieldMeta.ts
+++ b/packages/core/src/utils/fieldMeta.ts
@@ -46,6 +46,7 @@ export const FILTER_TAB_IDS = [
   'bitrate',
   'limit',
   'deduplicator',
+  'screener',
   'miscellaneous',
 ] as const;
 export type FilterTabId = (typeof FILTER_TAB_IDS)[number];
@@ -196,6 +197,7 @@ export const FIELD_META: Omit<Record<keyof UserData, FieldMeta>, IgnoredKeys> = 
 
   sortCriteria: { label: 'Sort Criteria', group: 'sorting', type: 'scalar', menu: 'sorting' },
   deduplicator: { label: 'Deduplicator', group: 'sorting', type: 'scalar', menu: 'filters', subTab: 'deduplicator' },
+  screener: { label: 'Screener', group: 'filters', type: 'scalar', menu: 'filters', subTab: 'screener' },
   resultLimits: { label: 'Result Limits', group: 'sorting', type: 'scalar', menu: 'filters', subTab: 'limit' },
 
   formatter: { label: 'Formatter', group: 'formatter', type: 'scalar', menu: 'formatter' },

--- a/packages/frontend/src/app/dashboard/screener/queries.ts
+++ b/packages/frontend/src/app/dashboard/screener/queries.ts
@@ -1,0 +1,138 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+
+export type Trust = 'full' | 'corroborate' | 'observe';
+export type SourceKind = 'local' | 'remote' | 'imported';
+
+export interface ScreenerSource {
+  id: string;
+  kind: SourceKind;
+  name: string;
+  url: string | null;
+  enabled: boolean;
+  trust: Trust;
+  refreshHours: number;
+  lastChecked: number;
+  lastUpdated: number;
+  status: string | null;
+  count: number;
+}
+
+export interface ScreenerSnapshot {
+  counts: { total: number; local: number };
+  sources: ScreenerSource[];
+}
+
+const ROOT = ['screener'] as const;
+
+export function useScreener() {
+  return useQuery({
+    queryKey: ROOT,
+    queryFn: () => api<ScreenerSnapshot>('/screener'),
+    staleTime: 10_000,
+  });
+}
+
+function useScreenerMutation<TArgs>(
+  fn: (args: TArgs) => Promise<unknown>
+) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: fn,
+    onSuccess: (data) => {
+      // Every mutation returns a fresh snapshot; seed the cache with it.
+      if (data && typeof data === 'object' && 'sources' in (data as object)) {
+        qc.setQueryData(ROOT, data);
+      } else {
+        qc.invalidateQueries({ queryKey: ROOT });
+      }
+    },
+  });
+}
+
+export interface AddRemoteArgs {
+  url: string;
+  name?: string;
+  trust?: Trust;
+  refreshHours?: number;
+}
+export function useAddRemoteSource() {
+  return useScreenerMutation((args: AddRemoteArgs) =>
+    api<ScreenerSnapshot & { id: string; status: string }>(
+      'POST /screener/sources/remote',
+      { body: args as unknown as Record<string, unknown> }
+    )
+  );
+}
+
+export interface UpdateSourceArgs {
+  id: string;
+  enabled?: boolean;
+  trust?: Trust;
+  refreshHours?: number;
+  name?: string;
+}
+export function useUpdateSource() {
+  return useScreenerMutation(({ id, ...patch }: UpdateSourceArgs) =>
+    api<ScreenerSnapshot>(`PATCH /screener/sources/${encodeURIComponent(id)}`, {
+      body: patch as Record<string, unknown>,
+    })
+  );
+}
+
+export function useRemoveSource() {
+  return useScreenerMutation(({ id, clear }: { id: string; clear?: boolean }) =>
+    api<ScreenerSnapshot>(
+      `DELETE /screener/sources/${encodeURIComponent(id)}${clear ? '?action=clear' : ''}`
+    )
+  );
+}
+
+export function useRefreshSource() {
+  return useScreenerMutation((id: string) =>
+    api<ScreenerSnapshot & { status: string }>(
+      `POST /screener/sources/${encodeURIComponent(id)}/refresh`
+    )
+  );
+}
+
+export interface ImportArgs {
+  content: string;
+  target: 'merge' | 'separate';
+  name?: string;
+  trust?: Trust;
+}
+export function useImportList() {
+  return useScreenerMutation((args: ImportArgs) =>
+    api<ScreenerSnapshot & { added: number; invalid: number }>(
+      'POST /screener/import',
+      { body: args as unknown as Record<string, unknown> }
+    )
+  );
+}
+
+export interface MarkArgs {
+  key: string;
+  verdict: 'dead' | 'fake' | 'mislabeled';
+}
+export function useMarkVerdict() {
+  return useScreenerMutation((args: MarkArgs) =>
+    api<ScreenerSnapshot>('POST /screener/mark', {
+      body: args as unknown as Record<string, unknown>,
+    })
+  );
+}
+
+/** Direct download URL for an export (auth cookie rides along). */
+export function exportUrl(
+  scope: 'local' | 'all',
+  format: 'native' | 'davex',
+  dedup: boolean
+): string {
+  const params = new URLSearchParams({
+    scope,
+    format,
+    dedup: dedup ? '1' : '0',
+  });
+  return `/api/v1/screener/export?${params.toString()}`;
+}

--- a/packages/frontend/src/app/dashboard/screener/screener-page.tsx
+++ b/packages/frontend/src/app/dashboard/screener/screener-page.tsx
@@ -1,0 +1,488 @@
+import React from 'react';
+import { toast } from 'sonner';
+import {
+  BiCloudDownload,
+  BiImport,
+  BiExport,
+  BiRefresh,
+  BiTrash,
+  BiEraser,
+} from 'react-icons/bi';
+import { PageWrapper } from '@/components/shared/page-wrapper';
+import { DashboardQueryBoundary } from '@/components/shared/dashboard-query-boundary';
+import {
+  useConfirmationDialog,
+  ConfirmationDialog,
+} from '@/components/shared/confirmation-dialog';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Modal } from '@/components/ui/modal';
+import { Switch } from '@/components/ui/switch';
+import { Select } from '@/components/ui/select';
+import { TextInput } from '@/components/ui/text-input';
+import { Textarea } from '@/components/ui/textarea';
+import { NumberInput } from '@/components/ui/number-input';
+import { cn } from '@/components/ui/core/styling';
+import {
+  useScreener,
+  useAddRemoteSource,
+  useUpdateSource,
+  useRemoveSource,
+  useRefreshSource,
+  useImportList,
+  exportUrl,
+  type ScreenerSource,
+  type Trust,
+} from './queries';
+
+const TRUST_OPTIONS = [
+  { value: 'full', label: 'full · filters on its own' },
+  { value: 'corroborate', label: 'corroborate · needs agreement' },
+  { value: 'observe', label: 'observe · never filters' },
+];
+
+function ago(sec: number): string {
+  if (!sec) return 'never';
+  const d = Date.now() / 1000 - sec;
+  if (d < 60) return 'just now';
+  if (d < 3600) return `${Math.floor(d / 60)}m ago`;
+  if (d < 86400) return `${Math.floor(d / 3600)}h ago`;
+  return `${Math.floor(d / 86400)}d ago`;
+}
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : 'Something went wrong.';
+}
+
+function KindBadge({ kind }: { kind: ScreenerSource['kind'] }) {
+  const label = kind === 'local' ? 'Local' : kind === 'remote' ? 'Remote' : 'Imported';
+  return (
+    <span
+      className={cn(
+        'rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide',
+        kind === 'local' && 'bg-brand/15 text-brand',
+        kind === 'remote' && 'bg-[--subtle] text-[--muted]',
+        kind === 'imported' && 'border border-[--border] text-[--muted]'
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+function SourceRow({ source }: { source: ScreenerSource }) {
+  const isLocal = source.kind === 'local';
+  const update = useUpdateSource();
+  const remove = useRemoveSource();
+  const refresh = useRefreshSource();
+  const busy = update.isPending || remove.isPending || refresh.isPending;
+  const statusErr = (source.status ?? '').startsWith('error');
+
+  const onRefresh = async () => {
+    try {
+      const data = await refresh.mutateAsync(source.id);
+      const s = (data as { status?: string }).status ?? 'ok';
+      toast[s.startsWith('error') ? 'error' : 'success'](`Refresh: ${s}`);
+    } catch (e) {
+      toast.error(errMsg(e));
+    }
+  };
+
+  const onRemove = async (clear: boolean) => {
+    try {
+      await remove.mutateAsync({ id: source.id, clear });
+      toast.success(clear ? `Cleared “${source.name}”.` : `Removed “${source.name}”.`);
+    } catch (e) {
+      toast.error(errMsg(e));
+    }
+  };
+
+  const confirmClear = useConfirmationDialog({
+    title: 'Clear source',
+    description: `Remove all ${source.count} entries from “${source.name}”? This can’t be undone.`,
+    actionText: 'Clear',
+    actionIntent: 'alert-subtle',
+    onConfirm: () => void onRemove(true),
+  });
+  const confirmRemove = useConfirmationDialog({
+    title: 'Remove source',
+    description: `Remove “${source.name}” and all its entries? This can’t be undone.`,
+    actionText: 'Remove',
+    actionIntent: 'alert-subtle',
+    onConfirm: () => void onRemove(false),
+  });
+
+  return (
+    <Card className={cn('p-4 space-y-3', !source.enabled && 'opacity-60')}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="font-medium truncate">{source.name}</span>
+            <KindBadge kind={source.kind} />
+          </div>
+          {source.url && (
+            <div className="text-xs text-[--muted] truncate font-mono">{source.url}</div>
+          )}
+          <div className="text-xs text-[--muted] mt-1">
+            {source.count.toLocaleString()} entries
+            {source.kind === 'remote' && (
+              <>
+                {' · '}
+                <span className={cn(statusErr && 'text-[--alert]')}>
+                  updated {ago(source.lastUpdated)}
+                  {source.status ? ` · ${source.status}` : ''}
+                </span>
+              </>
+            )}
+          </div>
+        </div>
+        <div className="flex shrink-0 gap-1.5">
+          {source.kind === 'remote' && (
+            <Button
+              size="sm"
+              intent="primary-outline"
+              disabled={busy}
+              leftIcon={<BiRefresh />}
+              onClick={onRefresh}
+            >
+              Refresh
+            </Button>
+          )}
+          <Button
+            size="sm"
+            intent="warning-subtle"
+            disabled={busy || source.count === 0}
+            leftIcon={<BiEraser />}
+            onClick={() => confirmClear.open()}
+          >
+            Clear
+          </Button>
+          {!isLocal && (
+            <Button
+              size="sm"
+              intent="alert-subtle"
+              disabled={busy}
+              leftIcon={<BiTrash />}
+              onClick={() => confirmRemove.open()}
+            >
+              Remove
+            </Button>
+          )}
+        </div>
+      </div>
+      <ConfirmationDialog {...confirmClear} />
+      {!isLocal && <ConfirmationDialog {...confirmRemove} />}
+
+      {!isLocal && (
+        <div className="flex flex-wrap items-center gap-4">
+          <div className="w-64">
+            <Select
+              size="sm"
+              value={source.trust}
+              options={TRUST_OPTIONS}
+              disabled={busy}
+              onValueChange={(v) =>
+                update
+                  .mutateAsync({ id: source.id, trust: v as Trust })
+                  .catch((e) => toast.error(errMsg(e)))
+              }
+            />
+          </div>
+          <Switch
+            label="Enabled"
+            value={source.enabled}
+            disabled={busy}
+            onValueChange={(v) =>
+              update
+                .mutateAsync({ id: source.id, enabled: v })
+                .catch((e) => toast.error(errMsg(e)))
+            }
+          />
+        </div>
+      )}
+      {isLocal && (
+        <div className="text-xs text-[--muted]">
+          Trust: full · always on. Fills in automatically from this instance.
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function AddRemoteModal() {
+  const [open, setOpen] = React.useState(false);
+  const [url, setUrl] = React.useState('');
+  const [name, setName] = React.useState('');
+  const [trust, setTrust] = React.useState<Trust>('corroborate');
+  const [refreshHours, setRefreshHours] = React.useState(24);
+  const add = useAddRemoteSource();
+
+  const submit = async () => {
+    try {
+      const data = await add.mutateAsync({ url: url.trim(), name: name.trim() || undefined, trust, refreshHours });
+      const status = (data as { status?: string }).status ?? 'added';
+      toast[status.startsWith('error') ? 'error' : 'success'](`Remote list: ${status}`);
+      setOpen(false);
+      setUrl('');
+      setName('');
+    } catch (e) {
+      toast.error(errMsg(e));
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={setOpen}
+      title="Add a remote list"
+      trigger={<Button intent="primary" leftIcon={<BiCloudDownload />}>Add remote list</Button>}
+    >
+      <div className="space-y-4">
+        <TextInput
+          label="List URL"
+          value={url}
+          onValueChange={setUrl}
+          placeholder="https://raw.githubusercontent.com/…/screener.ndjson.gz"
+        />
+        <TextInput
+          label="Name (optional)"
+          value={name}
+          onValueChange={setName}
+          placeholder="Community list"
+        />
+        <div className="flex gap-4">
+          <div className="flex-1">
+            <Select
+              label="Trust"
+              value={trust}
+              options={TRUST_OPTIONS}
+              onValueChange={(v) => setTrust(v as Trust)}
+            />
+          </div>
+          <div className="w-32">
+            <NumberInput
+              label="Refresh (h)"
+              value={refreshHours}
+              min={1}
+              max={720}
+              onValueChange={(n) => setRefreshHours(n || 24)}
+            />
+          </div>
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button intent="primary-outline" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button intent="primary" loading={add.isPending} disabled={!url.trim()} onClick={submit}>
+            Add &amp; fetch
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function ImportModal() {
+  const [open, setOpen] = React.useState(false);
+  const [content, setContent] = React.useState('');
+  const [target, setTarget] = React.useState<'merge' | 'separate'>('separate');
+  const [name, setName] = React.useState('');
+  const [trust, setTrust] = React.useState<Trust>('corroborate');
+  const importList = useImportList();
+
+  const onFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    // Drop any previously loaded text up front so a failed read can't leave
+    // stale content behind to be submitted.
+    setContent('');
+    try {
+      const isGz =
+        file.name.toLowerCase().endsWith('.gz') ||
+        file.type === 'application/gzip';
+      // Decompress .gz (e.g. an nzbdavex export) client-side before sending the
+      // plain NDJSON text the import endpoint expects.
+      const text = isGz
+        ? await new Response(
+            file.stream().pipeThrough(new DecompressionStream('gzip'))
+          ).text()
+        : await file.text();
+      setContent(text);
+    } catch {
+      toast.error('Could not read that file.');
+    }
+  };
+
+  const submit = async () => {
+    try {
+      const data = await importList.mutateAsync({
+        content,
+        target,
+        name: name.trim() || undefined,
+        trust,
+      });
+      const { added, invalid } = data as { added: number; invalid: number };
+      toast.success(
+        `Imported ${added.toLocaleString()} entr${added === 1 ? 'y' : 'ies'}${invalid ? ` · ${invalid} skipped` : ''}.`
+      );
+      setOpen(false);
+      setContent('');
+      setName('');
+    } catch (e) {
+      toast.error(errMsg(e));
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={setOpen}
+      title="Import a list"
+      trigger={<Button intent="primary-outline" leftIcon={<BiImport />}>Import</Button>}
+    >
+      <div className="space-y-4">
+        <p className="text-sm text-[--muted]">
+          Paste an NDJSON list (aiostreams or nzbdavex/warden format) or choose a file.
+        </p>
+        <Textarea
+          label="Entries"
+          value={content}
+          onValueChange={setContent}
+          rows={6}
+          placeholder={'{"k":"btih:…","v":"dead","n":1,"at":1719705600}'}
+        />
+        <input
+          type="file"
+          aria-label="Choose a list file to import"
+          accept=".ndjson,.json,.txt,.gz"
+          onChange={onFile}
+          className="text-sm text-[--muted]"
+        />
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            intent={target === 'separate' ? 'primary' : 'primary-outline'}
+            onClick={() => setTarget('separate')}
+          >
+            Keep as a source
+          </Button>
+          <Button
+            size="sm"
+            intent={target === 'merge' ? 'primary' : 'primary-outline'}
+            onClick={() => setTarget('merge')}
+          >
+            Merge into local
+          </Button>
+        </div>
+        {target === 'separate' && (
+          <div className="flex gap-4">
+            <div className="flex-1">
+              <TextInput label="Name" value={name} onValueChange={setName} placeholder="Imported list" />
+            </div>
+            <div className="w-44">
+              <Select
+                label="Trust"
+                value={trust}
+                options={TRUST_OPTIONS}
+                onValueChange={(v) => setTrust(v as Trust)}
+              />
+            </div>
+          </div>
+        )}
+        <div className="flex justify-end gap-2">
+          <Button intent="primary-outline" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button intent="primary" loading={importList.isPending} disabled={!content.trim()} onClick={submit}>
+            Import
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function ExportModal() {
+  const [open, setOpen] = React.useState(false);
+  const [scope, setScope] = React.useState<'local' | 'all'>('local');
+  const [format, setFormat] = React.useState<'native' | 'davex'>('native');
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={setOpen}
+      title="Export"
+      trigger={<Button intent="primary-outline" leftIcon={<BiExport />}>Export</Button>}
+    >
+      <div className="space-y-4">
+        <Select
+          label="What to export"
+          value={scope}
+          options={[
+            { value: 'local', label: 'My list only (clean, shareable)' },
+            { value: 'all', label: 'Everything (all sources)' },
+          ]}
+          onValueChange={(v) => setScope(v as 'local' | 'all')}
+        />
+        <Select
+          label="Format"
+          value={format}
+          options={[
+            { value: 'native', label: 'aiostreams (all source types)' },
+            { value: 'davex', label: 'nzbdavex / warden (dead usenet only)' },
+          ]}
+          onValueChange={(v) => setFormat(v as 'native' | 'davex')}
+        />
+        <div className="flex justify-end gap-2">
+          <Button intent="primary-outline" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button
+            intent="primary"
+            leftIcon={<BiExport />}
+            onClick={() => {
+              window.location.href = exportUrl(scope, format, true);
+              setOpen(false);
+            }}
+          >
+            Download
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+export function ScreenerPage() {
+  const query = useScreener();
+
+  return (
+    <PageWrapper className="p-4 sm:p-8 space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2>Screener</h2>
+          <p className="text-[--muted]">
+            {query.data
+              ? `${query.data.counts.total.toLocaleString()} entries across ${query.data.sources.length} source${query.data.sources.length === 1 ? '' : 's'}`
+              : 'Community-shared filter of dead, fake, and mislabeled releases'}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <AddRemoteModal />
+          <ImportModal />
+          <ExportModal />
+        </div>
+      </div>
+
+      <DashboardQueryBoundary query={query} errorTitle="Failed to load Screener">
+        {(data) => (
+          <div className="space-y-3">
+            {data.sources.map((s) => (
+              <SourceRow key={s.id} source={s} />
+            ))}
+          </div>
+        )}
+      </DashboardQueryBoundary>
+    </PageWrapper>
+  );
+}

--- a/packages/frontend/src/router.tsx
+++ b/packages/frontend/src/router.tsx
@@ -10,6 +10,7 @@ import {
   SystemPage,
   SettingsPage,
   ProxyPage,
+  ScreenerPage,
   UsersPage,
   TasksPage,
   CachePage,
@@ -166,6 +167,12 @@ const dashboardProxyRoute = createRoute({
   component: ProxyPage,
 });
 
+const dashboardScreenerRoute = createRoute({
+  getParentRoute: () => dashboardRoute,
+  path: 'screener',
+  component: ScreenerPage,
+});
+
 const dashboardUsersRoute = createRoute({
   getParentRoute: () => dashboardRoute,
   path: 'users',
@@ -243,6 +250,7 @@ const routeTree = rootRoute.addChildren([
     dashboardSystemRoute,
     dashboardSettingsRoute,
     dashboardProxyRoute,
+    dashboardScreenerRoute,
     dashboardUsersRoute,
     dashboardTasksRoute,
     dashboardCacheRoute,

--- a/packages/frontend/src/routes/dashboard-layout.tsx
+++ b/packages/frontend/src/routes/dashboard-layout.tsx
@@ -26,6 +26,7 @@ import {
   BiData,
   BiSliderAlt,
   BiCloudDownload,
+  BiShield,
 } from 'react-icons/bi';
 import { LayoutHeaderBackground } from '@/components/layout-header-background';
 import { SECTIONS } from '@/app/dashboard/usenet/sections';
@@ -49,6 +50,7 @@ const NAV: {
   // (wired up in the items mapping below).
   { label: 'Usenet', href: '/dashboard/usenet', icon: BiCloudDownload },
   { label: 'Proxy', href: '/dashboard/proxy', icon: BiNetworkChart },
+  { label: 'Screener', href: '/dashboard/screener', icon: BiShield },
   { label: 'Settings', href: '/dashboard/settings', icon: BiCog },
 ];
 

--- a/packages/frontend/src/routes/dashboard-pages.tsx
+++ b/packages/frontend/src/routes/dashboard-pages.tsx
@@ -4,6 +4,7 @@ export { AnalyticsPage } from '@/app/dashboard/analytics/analytics-page';
 export { SystemPage } from '@/app/dashboard/system/system-page';
 export { UsersPage } from '@/app/dashboard/users/users-page';
 export { ProxyPage } from '@/app/dashboard/proxy/proxy-page';
+export { ScreenerPage } from '@/app/dashboard/screener/screener-page';
 export { TasksPage } from '@/app/dashboard/tasks/tasks-page';
 export { CachePage } from '@/app/dashboard/cache/cache-page';
 export { UsenetLayout } from '@/app/dashboard/usenet/usenet-layout';

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -16,6 +16,7 @@ import {
   authApi,
   dashboardApi,
   usenetApi,
+  screenerApi,
 } from './routes/api/index.js';
 import {
   configure,
@@ -96,7 +97,7 @@ export const staticRoot = path.join(__dirname, './static');
 
 app.use(ipMiddleware);
 app.use(loggerMiddleware);
-app.use(express.json());
+app.use(express.json({ limit: '16mb' }));
 app.use(express.urlencoded({ extended: true }));
 
 // Allow all origins in development for easier testing
@@ -133,6 +134,7 @@ apiRouter.use('/sync', syncApi);
 apiRouter.use('/auth', authApi);
 apiRouter.use('/dashboard', dashboardApi);
 apiRouter.use('/usenet', usenetApi);
+apiRouter.use('/screener', screenerApi);
 apiRouter.use('/sabnzbd', sabnzbdRouter);
 apiRouter.use('/newznab', createNabRouter('newznab'));
 apiRouter.use('/torznab', createNabRouter('torznab'));

--- a/packages/server/src/routes/api/index.ts
+++ b/packages/server/src/routes/api/index.ts
@@ -14,3 +14,4 @@ export { default as syncApi } from './sync.js';
 export { default as authApi } from './auth.js';
 export { default as dashboardApi } from './dashboard.js';
 export { default as usenetApi } from './usenet.js';
+export { default as screenerApi } from './screener.js';

--- a/packages/server/src/routes/api/screener.ts
+++ b/packages/server/src/routes/api/screener.ts
@@ -1,0 +1,241 @@
+import { Router } from 'express';
+import {
+  APIError,
+  constants,
+  createLogger,
+  ScreenerStore,
+  ScreenerRemoteSourceService,
+  parseNdjson,
+  toNdjson,
+  toDavexNdjson,
+  isValidKey,
+  type ScreenerSource,
+} from '@aiostreams/core';
+import { z } from 'zod';
+import { requireAdmin } from '../../middlewares/auth.js';
+import { createResponse } from '../../utils/responses.js';
+
+const router: Router = Router();
+const logger = createLogger('screener');
+
+// The Screener store and its sources are instance-global and operator-managed.
+router.use(requireAdmin);
+
+const Trust = z.enum(['full', 'corroborate', 'observe']);
+const Verdict = z.enum(['dead', 'fake', 'mislabeled']);
+
+const badRequest = (message: string) =>
+  new APIError(constants.ErrorCode.MISSING_REQUIRED_FIELDS, undefined, message);
+
+const nowSec = () => Math.floor(Date.now() / 1000);
+
+async function snapshot() {
+  const [counts, sources] = await Promise.all([
+    ScreenerStore.getCounts(),
+    ScreenerStore.getSources(),
+  ]);
+  return { counts, sources };
+}
+
+// Current state: entry counts + every configured source.
+router.get('/', async (_req, res, next) => {
+  try {
+    res.json(createResponse({ success: true, data: await snapshot() }));
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Subscribe to a remote list (and fetch it immediately).
+const AddRemoteSchema = z.object({
+  name: z.string().trim().optional(),
+  url: z
+    .url()
+    .refine((u) => /^https?:\/\//i.test(u), 'URL must be http or https'),
+  trust: Trust.optional(),
+  refreshHours: z.number().int().min(1).max(720).optional(),
+});
+router.post('/sources/remote', async (req, res, next) => {
+  const parsed = AddRemoteSchema.safeParse(req.body);
+  if (!parsed.success) return next(badRequest('A valid url is required.'));
+  const { name, url, trust, refreshHours } = parsed.data;
+  try {
+    const id = await ScreenerStore.addSource(
+      'remote',
+      name || new URL(url).host,
+      url,
+      trust ?? 'corroborate',
+      refreshHours ?? 24
+    );
+    const source = (await ScreenerStore.getSources()).find((s) => s.id === id);
+    const status = source
+      ? await ScreenerRemoteSourceService.refreshOne(source)
+      : 'error: not found';
+    res.json(
+      createResponse({ success: true, data: { id, status, ...(await snapshot()) } })
+    );
+  } catch (err) {
+    next(err);
+  }
+});
+
+const UpdateSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    trust: Trust.optional(),
+    refreshHours: z.number().int().min(1).max(720).optional(),
+    name: z.string().trim().min(1).optional(),
+  })
+  .strict()
+  .refine((v) => Object.keys(v).length > 0);
+router.patch('/sources/:id', async (req, res, next) => {
+  const parsed = UpdateSchema.safeParse(req.body);
+  if (!parsed.success) return next(badRequest('Nothing valid to update.'));
+  try {
+    await ScreenerStore.updateSource(req.params.id, parsed.data);
+    res.json(createResponse({ success: true, data: await snapshot() }));
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Remove a source, or empty it with ?action=clear.
+router.delete('/sources/:id', async (req, res, next) => {
+  try {
+    if (req.query.action === 'clear') {
+      const removed = await ScreenerStore.clearSource(req.params.id);
+      res.json(
+        createResponse({ success: true, data: { removed, ...(await snapshot()) } })
+      );
+      return;
+    }
+    const ok = await ScreenerStore.removeSource(req.params.id);
+    if (!ok) return next(badRequest('The local source cannot be removed.'));
+    res.json(createResponse({ success: true, data: await snapshot() }));
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Re-fetch a remote source now.
+router.post('/sources/:id/refresh', async (req, res, next) => {
+  try {
+    const source = (await ScreenerStore.getSources()).find(
+      (s: ScreenerSource) => s.id === req.params.id
+    );
+    if (!source || source.kind !== 'remote') {
+      return next(badRequest('Not a remote source.'));
+    }
+    const status = await ScreenerRemoteSourceService.refreshOne(source);
+    res.json(
+      createResponse({ success: true, data: { status, ...(await snapshot()) } })
+    );
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Import an NDJSON list (native or davex format), merged into local or kept
+// as its own removable source.
+const ImportSchema = z.object({
+  content: z.string().min(1).max(16 * 1024 * 1024),
+  target: z.enum(['merge', 'separate']).default('separate'),
+  name: z.string().trim().optional(),
+  trust: Trust.optional(),
+});
+router.post('/import', async (req, res, next) => {
+  const parsed = ImportSchema.safeParse(req.body);
+  if (!parsed.success) return next(badRequest('Import content is required.'));
+  const { content, target, name, trust } = parsed.data;
+  try {
+    const { records, invalid } = parseNdjson(content);
+    if (records.length === 0) {
+      return next(badRequest('No valid entries found in the import.'));
+    }
+    let added: number;
+    if (target === 'merge') {
+      added = await ScreenerStore.bulkUpsert('local', records);
+    } else {
+      const id = await ScreenerStore.addSource(
+        'imported',
+        name || 'Imported list',
+        null,
+        trust ?? 'corroborate',
+        24
+      );
+      try {
+        added = await ScreenerStore.bulkUpsert(id, records, { replace: true });
+        await ScreenerStore.setSourceStatus(
+          id,
+          null,
+          nowSec(),
+          nowSec(),
+          `imported ${added}`
+        );
+      } catch (err) {
+        // Don't leave an empty orphaned source behind if the import write fails.
+        await ScreenerStore.removeSource(id).catch(() => {});
+        throw err;
+      }
+    }
+    res.json(
+      createResponse({
+        success: true,
+        data: { added, invalid, ...(await snapshot()) },
+      })
+    );
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Export as NDJSON. scope=local|all, format=native|davex, dedup=1.
+router.get('/export', async (req, res, next) => {
+  try {
+    const scope = req.query.scope === 'all' ? 'all' : 'local';
+    const format = req.query.format === 'davex' ? 'davex' : 'native';
+    const dedup = req.query.dedup !== '0';
+    const ids =
+      scope === 'all'
+        ? (await ScreenerStore.getSources()).map((s) => s.id)
+        : ['local'];
+    const records = await ScreenerStore.getEntries(ids, dedup);
+    const body =
+      format === 'davex'
+        ? toDavexNdjson(records, nowSec())
+        : toNdjson(records, nowSec());
+    res.type('application/x-ndjson');
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="screener.${format === 'davex' ? 'warden.' : ''}ndjson"`
+    );
+    res.send(body);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Manually contribute a verdict for a release key.
+const MarkSchema = z.object({
+  key: z.string(),
+  verdict: Verdict,
+  backbones: z.array(z.string()).optional(),
+});
+router.post('/mark', async (req, res, next) => {
+  const parsed = MarkSchema.safeParse(req.body);
+  if (!parsed.success || !isValidKey(parsed.data.key)) {
+    return next(badRequest('A valid release key and verdict are required.'));
+  }
+  try {
+    await ScreenerStore.markVerdict(
+      parsed.data.key,
+      parsed.data.verdict,
+      parsed.data.backbones ?? []
+    );
+    res.json(createResponse({ success: true, data: await snapshot() }));
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -24,6 +24,7 @@ import {
   TaskManager,
   drainUsenetMetrics,
   pruneUsenetMetrics,
+  ScreenerRemoteSourceService,
 } from '@aiostreams/core';
 
 const logger = createLogger('server');
@@ -134,6 +135,26 @@ function registerUsenetTasks() {
   });
 }
 
+function registerScreenerTask() {
+  TaskManager.register({
+    id: 'screener-remote-refresh',
+    label: 'Refresh Screener remote lists',
+    description:
+      'Re-fetches subscribed remote Screener lists whose refresh interval has ' +
+      'elapsed and replaces their stored entries.',
+    category: 'data-sync',
+    kind: 'scheduled',
+    intervalMs: 15 * 60_000,
+    enabled: true,
+    destructive: false,
+    multiReplica: 'single',
+    run: async () => {
+      await ScreenerRemoteSourceService.refreshDue();
+      return { ok: true };
+    },
+  });
+}
+
 async function initialiseRedis() {
   if (appConfig.bootstrap.redisUri) {
     await Cache.testRedisConnection();
@@ -189,6 +210,7 @@ async function start() {
     registerPruneTask();
     registerCacheTasks();
     registerUsenetTasks();
+    registerScreenerTask();
     await initialiseAuth();
     startAnalytics();
     const server = app.listen(appConfig.bootstrap.port, (error) => {


### PR DESCRIPTION
Adds Screener: an instance-global list of bad releases (dead, fake, mislabeled) that gets filtered out before results reach Stremio. Verdicts come from the local instance plus subscribed and imported lists, combined with a trust/quorum model and optional per-backbone scoping. Usenet releases use a credential-free wd1 fingerprint that interchanges with nzbdavex lists; torrents key by infohash. The local list auto-fills when the native usenet engine finds a release gone from every provider, and the skip counts feed the existing filter stats.

Config lives under the dashboard: sources, import/export, and per-user toggles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Screener dashboard for managing sources, importing/exporting lists, and viewing status.
  * Introduced Screener-based filtering of flagged releases (with Screener-specific removal reason tracking), plus remote source refresh and manual verdict actions (UI + API).
* **Bug Fixes**
  * Improved usenet Screener key handling by deriving, validating, and propagating keys for more accurate screening.
  * Added fail-open safeguards so playback continues if Screener data isn’t available or evaluation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->